### PR TITLE
Port Verdict to GPUs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,12 +80,20 @@ configure_file(
   @ONLY)
 
 add_library(verdict ${verdict_SOURCES} ${verdict_HEADERS} ${CMAKE_CURRENT_BINARY_DIR}/verdict_config.h)
+
 target_include_directories(verdict PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
-if(UNIX)
+
+if (UNIX)
   target_link_libraries(verdict PRIVATE m)
 endif()
 
+if (VERDICT_ENABLE_CUDA)
+  set_target_properties(verdict PROPERTIES CUDA_SEPARABLE_COMPILATION On)
+elseif (VERDICT_ENABLE_HIP)
+  target_compile_options(verdict PUBLIC -fgpu-rdc)
+  target_link_options(verdict PUBLIC -fgpu-rdc)
+endif ()
 
 # Setting the VERSION and SOVERSION of a library will include
 # version information either in the library, or in the library

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,10 +4,30 @@
 
 cmake_minimum_required(VERSION 3.16)
 
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED 1)
+set(CMAKE_CXX_STANDARD 11 CACHE STRING "")
+set(CMAKE_CXX_STANDARD_REQUIRED ON CACHE BOOL "")
 
-project(verdict VERSION 1.4.2)
+project(verdict
+        LANGUAGES CXX
+        VERSION 1.4.2)
+
+# Enable CUDA if requested
+option(VERDICT_ENABLE_CUDA "Build Verdict with CUDA support." OFF)
+
+if (VERDICT_ENABLE_CUDA)
+  enable_language(CUDA)
+endif ()
+
+# Enable HIP if requested
+option(VERDICT_ENABLE_HIP "Build Verdict with HIP support." OFF)
+
+if (VERDICT_ENABLE_HIP)
+  if(${CMAKE_VERSION} VERSION_LESS 3.21.0)
+    message(FATAL_ERROR "HIP support requires CMake 3.21 or above.")
+  endif()
+
+  enable_language(HIP)
+endif()
 
 # Includes
 include(GNUInstallDirs)
@@ -19,6 +39,7 @@ endif ()
 
 set(verdict_VERSION_FLAT "${verdict_VERSION_MAJOR}${verdict_VERSION_MINOR}${verdict_VERSION_PATCH}")
 
+option(BUILD_SHARED_LIBS "Build Verdict with shared libraries." OFF)
 option(VERDICT_BUILD_DOC "Build the 2007 Verdict User Manual" OFF)
 option(VERDICT_MANGLE "Mangle verdict names for inclusion in a larger library?" OFF)
 if (VERDICT_MANGLE)
@@ -30,6 +51,7 @@ mark_as_advanced(VERDICT_MANGLE)
 option(VERDICT_ENABLE_TESTING "Should tests of the VERDICT library be built?" ON)
 
 set(verdict_HEADERS
+  V_GaussIntegration.hpp
   verdict.h
   VerdictVector.hpp
   verdict_defines.hpp)
@@ -37,7 +59,6 @@ set(verdict_HEADERS
 set(verdict_SOURCES
   V_EdgeMetric.cpp
   V_GaussIntegration.cpp
-  V_GaussIntegration.hpp
   V_HexMetric.cpp
   V_KnifeMetric.cpp
   V_PyramidMetric.cpp
@@ -46,6 +67,12 @@ set(verdict_SOURCES
   V_TriMetric.cpp
   V_WedgeMetric.cpp
   VerdictVector.cpp)
+
+if (VERDICT_ENABLE_CUDA)
+  set_source_files_properties(${verdict_SOURCES} PROPERTIES LANGUAGE CUDA)
+elseif (VERDICT_ENABLE_HIP)
+  set_source_files_properties(${verdict_SOURCES} PROPERTIES LANGUAGE HIP)
+endif ()
 
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/verdict_config.h.in

--- a/V_EdgeMetric.cpp
+++ b/V_EdgeMetric.cpp
@@ -20,14 +20,14 @@
 
 #include "verdict.h"
 
-#include <cmath>
+#include <math.h>
 
 namespace VERDICT_NAMESPACE
 {
 /*!\brief Length of and edge.
  * Length is calculated by taking the distance between the end nodes.
  */
-double edge_length(int num_nodes, const double coordinates[][3])
+VERDICT_HOST_DEVICE double edge_length(int num_nodes, const double coordinates[][3])
 {
   double edge_length = 0.0;
 
@@ -36,19 +36,19 @@ double edge_length(int num_nodes, const double coordinates[][3])
     double x = coordinates[1][0] - coordinates[0][0];
     double y = coordinates[1][1] - coordinates[0][1];
     double z = coordinates[1][2] - coordinates[0][2];
-    edge_length = (double)(std::sqrt(x * x + y * y + z * z));   
+    edge_length = sqrt(x * x + y * y + z * z);
   }
   if (3 == num_nodes)
   {
     double x = coordinates[2][0] - coordinates[0][0];
     double y = coordinates[2][1] - coordinates[0][1];
     double z = coordinates[2][2] - coordinates[0][2];
-    edge_length += (double)(std::sqrt(x * x + y * y + z * z));
+    edge_length += sqrt(x * x + y * y + z * z);
 
     x = coordinates[2][0] - coordinates[1][0];
     y = coordinates[2][1] - coordinates[1][1];
     z = coordinates[2][2] - coordinates[1][2];
-    edge_length += (double)(std::sqrt(x * x + y * y + z * z));
+    edge_length += sqrt(x * x + y * y + z * z);
   }
 
   return edge_length;

--- a/V_GaussIntegration.cpp
+++ b/V_GaussIntegration.cpp
@@ -23,7 +23,7 @@
 
 namespace VERDICT_NAMESPACE
 {
-void GaussIntegration::initialize(int n, int m, int dim, int tri)
+VERDICT_HOST_DEVICE void GaussIntegration::initialize(int n, int m, int dim, int tri)
 {
   numberGaussPoints = n;
   numberNodes = m;
@@ -54,7 +54,7 @@ void GaussIntegration::initialize(int n, int m, int dim, int tri)
   }
 }
 
-void GaussIntegration::get_shape_func(double shape_function[], double dndy1_at_gauss_pts[],
+VERDICT_HOST_DEVICE void GaussIntegration::get_shape_func(double shape_function[], double dndy1_at_gauss_pts[],
   double dndy2_at_gauss_pts[], double gauss_weight[])
 {
   int i, j;
@@ -74,7 +74,7 @@ void GaussIntegration::get_shape_func(double shape_function[], double dndy1_at_g
   }
 }
 
-void GaussIntegration::get_shape_func(double shape_function[], double dndy1_at_gauss_pts[],
+VERDICT_HOST_DEVICE void GaussIntegration::get_shape_func(double shape_function[], double dndy1_at_gauss_pts[],
   double dndy2_at_gauss_pts[], double dndy3_at_gauss_pts[], double gauss_weight[])
 {
   int i, j;
@@ -95,7 +95,7 @@ void GaussIntegration::get_shape_func(double shape_function[], double dndy1_at_g
   }
 }
 
-void GaussIntegration::get_gauss_pts_and_weight()
+VERDICT_HOST_DEVICE void GaussIntegration::get_gauss_pts_and_weight()
 {
 
   switch (numberGaussPoints)
@@ -121,7 +121,7 @@ void GaussIntegration::get_gauss_pts_and_weight()
   }
 }
 
-void GaussIntegration::calculate_shape_function_2d_quad()
+VERDICT_HOST_DEVICE void GaussIntegration::calculate_shape_function_2d_quad()
 {
   int ife = 0, i, j;
   double y1, y2;
@@ -200,7 +200,7 @@ void GaussIntegration::calculate_shape_function_2d_quad()
   }
 }
 
-void GaussIntegration::calculate_shape_function_3d_hex()
+VERDICT_HOST_DEVICE void GaussIntegration::calculate_shape_function_3d_hex()
 {
   int ife = 0, i, j, k, node_id;
   double y1, y2, y3, sign_node_y1, sign_node_y2, sign_node_y3;
@@ -327,7 +327,7 @@ void GaussIntegration::calculate_shape_function_3d_hex()
   }
 }
 
-void GaussIntegration::calculate_derivative_at_nodes(
+VERDICT_HOST_DEVICE void GaussIntegration::calculate_derivative_at_nodes(
   double dndy1_at_nodes[][maxNumberNodes], double dndy2_at_nodes[][maxNumberNodes])
 {
   double y1 = 0., y2 = 0.;
@@ -419,7 +419,7 @@ void GaussIntegration::calculate_derivative_at_nodes(
   }
 }
 
-void GaussIntegration::calculate_derivative_at_nodes_3d(double dndy1_at_nodes[][maxNumberNodes],
+VERDICT_HOST_DEVICE void GaussIntegration::calculate_derivative_at_nodes_3d(double dndy1_at_nodes[][maxNumberNodes],
   double dndy2_at_nodes[][maxNumberNodes], double dndy3_at_nodes[][maxNumberNodes])
 {
   double y1, y2, y3, sign_node_y1, sign_node_y2, sign_node_y3;
@@ -514,7 +514,7 @@ void GaussIntegration::calculate_derivative_at_nodes_3d(double dndy1_at_nodes[][
   }
 }
 
-void GaussIntegration::get_signs_for_node_local_coord_hex(
+VERDICT_HOST_DEVICE void GaussIntegration::get_signs_for_node_local_coord_hex(
   int node_id, double& sign_node_y1, double& sign_node_y2, double& sign_node_y3)
 {
   switch (node_id)
@@ -629,7 +629,7 @@ void GaussIntegration::get_signs_for_node_local_coord_hex(
   }
 }
 
-void GaussIntegration::get_tri_rule_pts_and_weight()
+VERDICT_HOST_DEVICE void GaussIntegration::get_tri_rule_pts_and_weight()
 {
   // get triangular rule integration points and weight
   switch (numberGaussPoints)
@@ -666,7 +666,7 @@ void GaussIntegration::get_tri_rule_pts_and_weight()
   }
 }
 
-void GaussIntegration::calculate_shape_function_2d_tri()
+VERDICT_HOST_DEVICE void GaussIntegration::calculate_shape_function_2d_tri()
 {
   int ife;
   double y1, y2, y3;
@@ -704,7 +704,7 @@ void GaussIntegration::calculate_shape_function_2d_tri()
   }
 }
 
-void GaussIntegration::calculate_derivative_at_nodes_2d_tri(
+VERDICT_HOST_DEVICE void GaussIntegration::calculate_derivative_at_nodes_2d_tri(
   double dndy1_at_nodes[][maxNumberNodes], double dndy2_at_nodes[][maxNumberNodes])
 {
   double y1 = 0., y2 = 0., y3;
@@ -759,7 +759,7 @@ void GaussIntegration::calculate_derivative_at_nodes_2d_tri(
   }
 }
 
-void GaussIntegration::get_tet_rule_pts_and_weight()
+VERDICT_HOST_DEVICE void GaussIntegration::get_tet_rule_pts_and_weight()
 {
   // get tetrahedron rule integration points and weight
   double a, b;
@@ -807,7 +807,7 @@ void GaussIntegration::get_tet_rule_pts_and_weight()
   }
 }
 
-void GaussIntegration::calculate_shape_function_3d_tet()
+VERDICT_HOST_DEVICE void GaussIntegration::calculate_shape_function_3d_tet()
 {
   int ife;
   double y1, y2, y3, y4;
@@ -913,7 +913,7 @@ void GaussIntegration::calculate_shape_function_3d_tet()
   }
 }
 
-void GaussIntegration::calculate_derivative_at_nodes_3d_tet(double dndy1_at_nodes[][maxNumberNodes],
+VERDICT_HOST_DEVICE void GaussIntegration::calculate_derivative_at_nodes_3d_tet(double dndy1_at_nodes[][maxNumberNodes],
   double dndy2_at_nodes[][maxNumberNodes], double dndy3_at_nodes[][maxNumberNodes])
 {
   double y1, y2, y3, y4;
@@ -989,7 +989,7 @@ void GaussIntegration::calculate_derivative_at_nodes_3d_tet(double dndy1_at_node
   }
 }
 
-void GaussIntegration::get_node_local_coord_tet(
+VERDICT_HOST_DEVICE void GaussIntegration::get_node_local_coord_tet(
   int node_id, double& y1, double& y2, double& y3, double& y4)
 {
   switch (node_id)

--- a/V_GaussIntegration.hpp
+++ b/V_GaussIntegration.hpp
@@ -25,72 +25,72 @@
 
 namespace VERDICT_NAMESPACE
 {
-#define maxTotalNumberGaussPoints 27
-#define maxNumberNodes 20
-#define maxNumberGaussPoints 3
-#define maxNumberGaussPointsTri 6
-#define maxNumberGaussPointsTet 4
+static constexpr int maxTotalNumberGaussPoints = 27;
+static constexpr int maxNumberNodes = 20;
+static constexpr int maxNumberGaussPoints = 3;
+static constexpr int maxNumberGaussPointsTri = 6;
+static constexpr int maxNumberGaussPointsTet = 4;
 
 struct GaussIntegration
 {
-  void get_signs_for_node_local_coord_hex(
+  VERDICT_HOST_DEVICE void get_signs_for_node_local_coord_hex(
     int node_id, double& sign_y1, double& sign_y2, double& sign_y3);
   //- to get the signs for  coordinates of hex nodes in the local computational space
 
   // constructors
-  void initialize(int n = 2, int m = 4, int dim = 2, int tri = 0);
+  VERDICT_HOST_DEVICE void initialize(int n = 2, int m = 4, int dim = 2, int tri = 0);
 
   // manipulators
-  void get_gauss_pts_and_weight();
+  VERDICT_HOST_DEVICE void get_gauss_pts_and_weight();
   //- get gauss point locations and weights
 
-  void get_tri_rule_pts_and_weight();
+  VERDICT_HOST_DEVICE void get_tri_rule_pts_and_weight();
   //- get integration points and weights for triangular rules
 
-  void calculate_shape_function_2d_tri();
+  VERDICT_HOST_DEVICE void calculate_shape_function_2d_tri();
   //- calculate the shape functions and derivatives of shape functions
   //- at integration points for 2D triangular elements
 
-  void calculate_shape_function_2d_quad();
+  VERDICT_HOST_DEVICE void calculate_shape_function_2d_quad();
   //- calculate the shape functions and derivatives of shape functions
   //- at gaussian points for 2D quad elements
 
-  void get_shape_func(double shape_function[], double dndy1_at_gauss_pts[],
+  VERDICT_HOST_DEVICE void get_shape_func(double shape_function[], double dndy1_at_gauss_pts[],
     double dndy2_at_gauss_ptsp[], double gauss_weight[]);
   //- get shape functions and the derivatives
 
-  void get_shape_func(double shape_function[], double dndy1_at_gauss_pts[],
+  VERDICT_HOST_DEVICE void get_shape_func(double shape_function[], double dndy1_at_gauss_pts[],
     double dndy2_at_gauss_pts[], double dndy3_at_gauss_pts[], double gauss_weight[]);
   //- get shape functions and the derivatives for 3D elements
 
-  void calculate_derivative_at_nodes(
+  VERDICT_HOST_DEVICE void calculate_derivative_at_nodes(
     double dndy1_at_nodes[][maxNumberNodes], double dndy2_at_nodes[][maxNumberNodes]);
   //- calculate shape function derivatives at nodes
 
-  void calculate_shape_function_3d_hex();
+  VERDICT_HOST_DEVICE void calculate_shape_function_3d_hex();
   //- calculate shape functions and derivatives of shape functions
   //- at gaussian points for 3D hex elements
 
-  void calculate_derivative_at_nodes_3d(double dndy1_at_nodes[][maxNumberNodes],
+  VERDICT_HOST_DEVICE void calculate_derivative_at_nodes_3d(double dndy1_at_nodes[][maxNumberNodes],
     double dndy2_at_nodes[][maxNumberNodes], double dndy3_at_nodes[][maxNumberNodes]);
   //- calculate shape function derivatives at nodes for hex elements
 
-  void calculate_derivative_at_nodes_2d_tri(
+  VERDICT_HOST_DEVICE void calculate_derivative_at_nodes_2d_tri(
     double dndy1_at_nodes[][maxNumberNodes], double dndy2_at_nodes[][maxNumberNodes]);
   //- calculate shape function derivatives at nodes for triangular elements
 
-  void calculate_shape_function_3d_tet();
+  VERDICT_HOST_DEVICE void calculate_shape_function_3d_tet();
   //- calculate shape functions and derivatives of shape functions
   //- at integration points for 3D tet elements
 
-  void get_tet_rule_pts_and_weight();
+  VERDICT_HOST_DEVICE void get_tet_rule_pts_and_weight();
   //- get integration points and weights for tetrhedron rules
 
-  void calculate_derivative_at_nodes_3d_tet(double dndy1_at_nodes[][maxNumberNodes],
+  VERDICT_HOST_DEVICE void calculate_derivative_at_nodes_3d_tet(double dndy1_at_nodes[][maxNumberNodes],
     double dndy2_at_nodes[][maxNumberNodes], double dndy3_at_nodes[][maxNumberNodes]);
   //- calculate shape function derivatives at nodes for tetrahedron elements
 
-  void get_node_local_coord_tet(int node_id, double& y1, double& y2, double& y3, double& y4);
+  VERDICT_HOST_DEVICE void get_node_local_coord_tet(int node_id, double& y1, double& y2, double& y3, double& y4);
   //- get nodal volume coordinates for tetrahedron element
 
   int numberGaussPoints;

--- a/V_HexMetric.cpp
+++ b/V_HexMetric.cpp
@@ -23,19 +23,18 @@
 #include "VerdictVector.hpp"
 #include "verdict.h"
 
-#include <algorithm>
-#include <cmath> // for std::isnan
+#include <math.h>
 
 namespace VERDICT_NAMESPACE
 {
-extern void quad_minimum_maximum_angle(double min_max_angles[2], const double coordinates[][3]);
+VERDICT_HOST_DEVICE extern void quad_minimum_maximum_angle(double min_max_angles[2], const double coordinates[][3]);
 
-static const double one_third = 1.0 / 3.0;
-static const double two_thirds = 2.0 / 3.0;
-static const double sqrt3 = std::sqrt(3.0);
+static constexpr double one_third = 1.0 / 3.0;
+static constexpr double two_thirds = 2.0 / 3.0;
+static constexpr double four_thirds = 4.0 / 3.0;
 
 //! weights based on the average size of a hex
-static int hex_get_weight(
+VERDICT_HOST_DEVICE static int hex_get_weight(
   VerdictVector& v1, VerdictVector& v2, VerdictVector& v3, double average_size)
 {
   if (average_size == 0)
@@ -47,7 +46,7 @@ static int hex_get_weight(
   v2.set(0, 1, 0);
   v3.set(0, 0, 1);
 
-  double scale = std::pow(average_size / (VerdictVector::Dot(v1, (v2 * v3))), 0.33333333333);
+  double scale = pow(average_size / (VerdictVector::Dot(v1, (v2 * v3))), one_third);
   v1 *= scale;
   v2 *= scale;
   v3 *= scale;
@@ -55,55 +54,158 @@ static int hex_get_weight(
   return 1;
 }
 
-static const double HEX27_node_local_coord[27][3] = { { -1, -1, -1 }, { 1, -1, -1 }, { 1, 1, -1 },
-  { -1, 1, -1 }, { -1, -1, 1 }, { 1, -1, 1 }, { 1, 1, 1 }, { -1, 1, 1 }, { 0, -1, -1 },
-  { 1, 0, -1 }, { 0, 1, -1 }, { -1, 0, -1 }, { -1, -1, 0 }, { 1, -1, 0 }, { 1, 1, 0 }, { -1, 1, 0 },
-  { 0, -1, 1 }, { 1, 0, 1 }, { 0, 1, 1 }, { -1, 0, 1 }, { 0, 0, 0 }, { 0, 0, -1 }, { 0, 0, 1 },
-  { -1, 0, 0 }, { 1, 0, 0 }, { 0, -1, 0 }, { 0, 1, 0 } };
+VERDICT_HOST_DEVICE static const double* HEX27_node_local_coord(int i)
+{
+  static const double s_HEX27_node_local_coord[27][3] = {
+    { -1, -1, -1 },
+    {  1, -1, -1 },
+    {  1,  1, -1 },
+    { -1,  1, -1 },
+    { -1, -1,  1 },
+    {  1, -1,  1 },
+    {  1,  1,  1 },
+    { -1,  1,  1 },
+    {  0, -1, -1 },
+    {  1,  0, -1 },
+    {  0,  1, -1 },
+    { -1,  0, -1 },
+    { -1, -1,  0 },
+    {  1, -1,  0 },
+    {  1,  1,  0 },
+    { -1,  1,  0 },
+    {  0, -1,  1 },
+    {  1,  0,  1 },
+    {  0,  1,  1 },
+    { -1,  0,  1 },
+    {  0,  0,  0 },
+    {  0,  0, -1 },
+    {  0,  0,  1 },
+    { -1,  0,  0 },
+    {  1,  0,  0 },
+    {  0, -1,  0 },
+    {  0,  1,  0 }
+  };
 
-static int hex20_subtet_conn[36][4] = { { 0, 12, 8, 20 }, { 4, 16, 12, 20 }, { 16, 5, 13, 20 },
-  { 1, 8, 13, 20 }, { 8, 12, 16, 20 }, { 8, 16, 13, 20 },
+  return s_HEX27_node_local_coord[i];
+}
 
-  { 1, 13, 9, 20 }, { 5, 17, 13, 20 }, { 6, 14, 17, 20 }, { 2, 9, 14, 20 }, { 9, 17, 14, 20 },
-  { 9, 13, 17, 20 },
+VERDICT_HOST_DEVICE static const int* hex20_subtet_conn(int i)
+{
+  static const int s_hex20_subtet_conn[36][4] = {
+    {  0, 12,  8, 20 },
+    {  4, 16, 12, 20 },
+    { 16,  5, 13, 20 },
+    {  1,  8, 13, 20 },
+    {  8, 12, 16, 20 },
+    {  8, 16, 13, 20 },
 
-  { 7, 15, 18, 20 }, { 3, 10, 15, 20 }, { 2, 14, 10, 20 }, { 6, 18, 14, 20 }, { 10, 18, 15, 20 },
-  { 10, 14, 18, 20 },
+    {  1, 13,  9, 20 },
+    {  5, 17, 13, 20 },
+    {  6, 14, 17, 20 },
+    {  2,  9, 14, 20 },
+    {  9, 17, 14, 20 },
+    {  9, 13, 17, 20 },
 
-  { 7, 19, 15, 20 }, { 4, 12, 19, 20 }, { 0, 11, 12, 20 }, { 3, 15, 11, 20 }, { 11, 19, 12, 20 },
-  { 11, 15, 19, 20 },
+    {  7, 15, 18, 20 },
+    {  3, 10, 15, 20 },
+    {  2, 14, 10, 20 },
+    {  6, 18, 14, 20 },
+    { 10, 18, 15, 20 },
+    { 10, 14, 18, 20 },
 
-  { 4, 19, 16, 20 }, { 5, 16, 17, 20 }, { 6, 17, 18, 20 }, { 7, 18, 19, 20 }, { 16, 18, 17, 20 },
-  { 16, 19, 18, 20 },
+    {  7, 19, 15, 20 },
+    {  4, 12, 19, 20 },
+    {  0, 11, 12, 20 },
+    {  3, 15, 11, 20 },
+    { 11, 19, 12, 20 },
+    { 11, 15, 19, 20 },
 
-  { 0, 8, 11, 20 }, { 8, 1, 9, 20 }, { 2, 10, 9, 20 }, { 3, 11, 10, 20 }, { 8, 9, 10, 20 },
-  { 8, 10, 11, 20 } };
+    {  4, 19, 16, 20 },
+    {  5, 16, 17, 20 },
+    {  6, 17, 18, 20 },
+    {  7, 18, 19, 20 },
+    { 16, 18, 17, 20 },
+    { 16, 19, 18, 20 },
 
-static int hex27_subtet_conn[48][4] = { { 0, 12, 8, 20 }, { 4, 16, 12, 20 }, { 16, 5, 13, 20 },
-  { 1, 8, 13, 20 }, { 25, 8, 12, 20 }, { 25, 12, 16, 20 }, { 25, 16, 13, 20 }, { 25, 13, 8, 20 },
+    {  0,  8, 11, 20 },
+    {  8,  1,  9, 20 },
+    {  2, 10,  9, 20 },
+    {  3, 11, 10, 20 },
+    {  8,  9, 10, 20 },
+    {  8, 10, 11, 20 }
+  };
 
-  { 1, 13, 9, 20 }, { 5, 17, 13, 20 }, { 6, 14, 17, 20 }, { 2, 9, 14, 20 }, { 24, 9, 13, 20 },
-  { 24, 13, 17, 20 }, { 24, 17, 14, 20 }, { 24, 14, 9, 20 },
+  return s_hex20_subtet_conn[i];
+}
 
-  { 7, 15, 18, 20 }, { 3, 10, 15, 20 }, { 2, 14, 10, 20 }, { 6, 18, 14, 20 }, { 26, 10, 14, 20 },
-  { 26, 14, 18, 20 }, { 26, 18, 15, 20 }, { 26, 15, 10, 20 },
+VERDICT_HOST_DEVICE static const int* hex27_subtet_conn(int i)
+{
+  static const int s_hex27_subtet_conn[48][4] = {
+    {  0, 12,  8, 20 },
+    {  4, 16, 12, 20 },
+    { 16,  5, 13, 20 },
+    {  1,  8, 13, 20 },
+    { 25,  8, 12, 20 },
+    { 25, 12, 16, 20 },
+    { 25, 16, 13, 20 },
+    { 25, 13,  8, 20 },
 
-  { 7, 19, 15, 20 }, { 4, 12, 19, 20 }, { 0, 11, 12, 20 }, { 3, 15, 11, 20 }, { 23, 11, 15, 20 },
-  { 23, 15, 19, 20 }, { 23, 19, 12, 20 }, { 23, 12, 11, 20 },
+    {  1, 13,  9, 20 },
+    {  5, 17, 13, 20 },
+    {  6, 14, 17, 20 },
+    {  2,  9, 14, 20 },
+    { 24,  9, 13, 20 },
+    { 24, 13, 17, 20 },
+    { 24, 17, 14, 20 },
+    { 24, 14,  9, 20 },
 
-  { 4, 19, 16, 20 }, { 5, 16, 17, 20 }, { 6, 17, 18, 20 }, { 7, 18, 19, 20 }, { 22, 16, 19, 20 },
-  { 22, 19, 18, 20 }, { 22, 18, 17, 20 }, { 22, 17, 16, 20 },
+    {  7, 15, 18, 20 },
+    {  3, 10, 15, 20 },
+    {  2, 14, 10, 20 },
+    {  6, 18, 14, 20 },
+    { 26, 10, 14, 20 },
+    { 26, 14, 18, 20 },
+    { 26, 18, 15, 20 },
+    { 26, 15, 10, 20 },
 
-  { 0, 8, 11, 20 }, { 8, 1, 9, 20 }, { 2, 10, 9, 20 }, { 3, 11, 10, 20 }, { 21, 8, 9, 20 },
-  { 21, 9, 10, 20 }, { 21, 10, 11, 20 }, { 21, 11, 8, 20 } };
+    {  7, 19, 15, 20 },
+    {  4, 12, 19, 20 },
+    {  0, 11, 12, 20 },
+    {  3, 15, 11, 20 },
+    { 23, 11, 15, 20 },
+    { 23, 15, 19, 20 },
+    { 23, 19, 12, 20 },
+    { 23, 12, 11, 20 },
 
-static double compute_tet_volume(VerdictVector& v1, VerdictVector& v2, VerdictVector& v3)
+    {  4, 19, 16, 20 },
+    {  5, 16, 17, 20 },
+    {  6, 17, 18, 20 },
+    {  7, 18, 19, 20 },
+    { 22, 16, 19, 20 },
+    { 22, 19, 18, 20 },
+    { 22, 18, 17, 20 },
+    { 22, 17, 16, 20 },
+
+    {  0,  8, 11, 20 },
+    {  8,  1,  9, 20 },
+    {  2, 10,  9, 20 },
+    {  3, 11, 10, 20 },
+    { 21,  8,  9, 20 },
+    { 21,  9, 10, 20 },
+    { 21, 10, 11, 20 },
+    { 21, 11,  8, 20 }
+  };
+
+  return s_hex27_subtet_conn[i];
+}
+
+VERDICT_HOST_DEVICE static double compute_tet_volume(VerdictVector& v1, VerdictVector& v2, VerdictVector& v3)
 {
   return (double)((v3 % (v1 * v2)) / 6.0);
 }
 
 // Compute interior node
-VerdictVector hex20_auxillary_node_coordinate(const double coordinates[][3])
+VERDICT_HOST_DEVICE VerdictVector hex20_auxillary_node_coordinate(const double coordinates[][3])
 {
   VerdictVector aux_node(0.0, 0.0, 0.0);
   for (int i = 0; i < 8; i++)
@@ -116,7 +218,7 @@ VerdictVector hex20_auxillary_node_coordinate(const double coordinates[][3])
   return aux_node;
 }
 
-static void HEX27_gradients_of_the_shape_functions_for_RST(
+VERDICT_HOST_DEVICE static void HEX27_gradients_of_the_shape_functions_for_RST(
   const double rst[3], double dhdr[27], double dhds[27], double dhdt[27])
 {
   double g1r = -0.5 * rst[0] * (1 - rst[0]);
@@ -251,7 +353,7 @@ static void HEX27_gradients_of_the_shape_functions_for_RST(
   }
 
 //! make VerdictVectors from coordinates
-static void make_hex_edges(const double coordinates[][3], VerdictVector edges[12])
+VERDICT_HOST_DEVICE static void make_hex_edges(const double coordinates[][3], VerdictVector edges[12])
 {
   edges[0].set(coordinates[1][0] - coordinates[0][0], coordinates[1][1] - coordinates[0][1],
     coordinates[1][2] - coordinates[0][2]);
@@ -283,7 +385,7 @@ static void make_hex_edges(const double coordinates[][3], VerdictVector edges[12
 /*!
   localizes hex coordinates
  */
-static void localize_hex_coordinates(const double coordinates[][3], VerdictVector position[8] )
+VERDICT_HOST_DEVICE static void localize_hex_coordinates(const double coordinates[][3], VerdictVector position[8] )
 {
 
   int ii;
@@ -320,8 +422,8 @@ static void localize_hex_coordinates(const double coordinates[][3], VerdictVecto
   double DY = point_1256.y() - point_0374.y();
   double DZ = point_1256.z() - point_0374.z();
 
-  double AMAGX = std::sqrt(DX*DX + DZ*DZ);
-  double AMAGY = std::sqrt(DX*DX + DY*DY + DZ*DZ);
+  double AMAGX = sqrt(DX*DX + DZ*DZ);
+  double AMAGY = sqrt(DX*DX + DY*DY + DZ*DZ);
   double FMAGX = AMAGX == 0.0 ? 1.0 : 0.0;
   double FMAGY = AMAGY == 0.0 ? 1.0 : 0.0;
 
@@ -355,7 +457,7 @@ static void localize_hex_coordinates(const double coordinates[][3], VerdictVecto
   DY = delta.y();
   DZ = delta.z();
 
-  AMAGY = std::sqrt(DY*DY + DZ*DZ);
+  AMAGY = sqrt(DY*DY + DZ*DZ);
   FMAGY = AMAGY == 0.0 ? 1.0 : 0.0;
 
   double CX = DY / (AMAGY + FMAGY) + FMAGY;
@@ -369,7 +471,7 @@ static void localize_hex_coordinates(const double coordinates[][3], VerdictVecto
   }
 }
 
-static double safe_ratio3( const double numerator, 
+VERDICT_HOST_DEVICE static double safe_ratio3( const double numerator, 
     const double denominator,
     const double max_ratio )
 {
@@ -378,13 +480,13 @@ static double safe_ratio3( const double numerator,
 
   const double filter_n = max_ratio * 1.0e-16;
   const double filter_d = 1.0e-16;
-  if ( std::abs( numerator ) <= filter_n && std::abs( denominator ) >= filter_d )
+  if ( fabs( numerator ) <= filter_n && fabs( denominator ) >= filter_d )
   {
     return_value = numerator / denominator;
   }
   else
   {
-    return_value = std::abs(numerator) / max_ratio >= std::abs(denominator) ?
+    return_value = fabs(numerator) / max_ratio >= fabs(denominator) ?
       ( (numerator >= 0.0 && denominator >= 0.0) ||
         (numerator < 0.0 && denominator < 0.0) ?
         max_ratio : -max_ratio )
@@ -394,13 +496,13 @@ static double safe_ratio3( const double numerator,
 }
 #endif /* Not currently used and not exposed in verdict.h */
 
-static double safe_ratio(const double numerator, const double denominator)
+VERDICT_HOST_DEVICE static double safe_ratio(const double numerator, const double denominator)
 {
 
   double return_value;
   const double filter_n = VERDICT_DBL_MAX;
   const double filter_d = VERDICT_DBL_MIN;
-  if (std::abs(numerator) <= filter_n && std::abs(denominator) >= filter_d)
+  if (fabs(numerator) <= filter_n && fabs(denominator) >= filter_d)
   {
     return_value = numerator / denominator;
   }
@@ -412,7 +514,7 @@ static double safe_ratio(const double numerator, const double denominator)
   return return_value;
 }
 
-static double condition_comp(
+VERDICT_HOST_DEVICE static double condition_comp(
   const VerdictVector& xxi, const VerdictVector& xet, const VerdictVector& xze)
 {
   double det = VerdictVector::Dot(xxi, (xet * xze));
@@ -427,10 +529,10 @@ static double condition_comp(
   double term2 = VerdictVector::Dot((xxi * xet), (xxi * xet)) +
     VerdictVector::Dot((xet * xze), (xet * xze)) + VerdictVector::Dot((xze * xxi), (xze * xxi));
 
-  return std::sqrt(term1 * term2) / det;
+  return sqrt(term1 * term2) / det;
 }
 
-static double oddy_comp(
+VERDICT_HOST_DEVICE static double oddy_comp(
   const VerdictVector& xxi, const VerdictVector& xet, const VerdictVector& xze)
 {
   double g11, g12, g13, g22, g23, g33, rt_g;
@@ -452,7 +554,7 @@ static double oddy_comp(
     double norm_J_squared = g11 + g22 + g33;
 
     oddy_metric = (norm_G_squared - one_third * norm_J_squared * norm_J_squared) /
-      std::pow(rt_g, 4. * one_third);
+      pow(rt_g, four_thirds);
   }
   else
   {
@@ -462,7 +564,7 @@ static double oddy_comp(
 }
 
 //! calculates edge lengths of a hex
-static double hex_edge_length(int max_min, const double coordinates[][3])
+VERDICT_HOST_DEVICE static double hex_edge_length(int max_min, const double coordinates[][3])
 {
   double temp[3], edge[12];
   int i;
@@ -473,84 +575,84 @@ static double hex_edge_length(int max_min, const double coordinates[][3])
     temp[i] = coordinates[1][i] - coordinates[0][i];
     temp[i] = temp[i] * temp[i];
   }
-  edge[0] = std::sqrt(temp[0] + temp[1] + temp[2]);
+  edge[0] = sqrt(temp[0] + temp[1] + temp[2]);
 
   for (i = 0; i < 3; i++)
   {
     temp[i] = coordinates[2][i] - coordinates[1][i];
     temp[i] = temp[i] * temp[i];
   }
-  edge[1] = std::sqrt(temp[0] + temp[1] + temp[2]);
+  edge[1] = sqrt(temp[0] + temp[1] + temp[2]);
 
   for (i = 0; i < 3; i++)
   {
     temp[i] = coordinates[3][i] - coordinates[2][i];
     temp[i] = temp[i] * temp[i];
   }
-  edge[2] = std::sqrt(temp[0] + temp[1] + temp[2]);
+  edge[2] = sqrt(temp[0] + temp[1] + temp[2]);
 
   for (i = 0; i < 3; i++)
   {
     temp[i] = coordinates[0][i] - coordinates[3][i];
     temp[i] = temp[i] * temp[i];
   }
-  edge[3] = std::sqrt(temp[0] + temp[1] + temp[2]);
+  edge[3] = sqrt(temp[0] + temp[1] + temp[2]);
 
   for (i = 0; i < 3; i++)
   {
     temp[i] = coordinates[5][i] - coordinates[4][i];
     temp[i] = temp[i] * temp[i];
   }
-  edge[4] = std::sqrt(temp[0] + temp[1] + temp[2]);
+  edge[4] = sqrt(temp[0] + temp[1] + temp[2]);
 
   for (i = 0; i < 3; i++)
   {
     temp[i] = coordinates[6][i] - coordinates[5][i];
     temp[i] = temp[i] * temp[i];
   }
-  edge[5] = std::sqrt(temp[0] + temp[1] + temp[2]);
+  edge[5] = sqrt(temp[0] + temp[1] + temp[2]);
 
   for (i = 0; i < 3; i++)
   {
     temp[i] = coordinates[7][i] - coordinates[6][i];
     temp[i] = temp[i] * temp[i];
   }
-  edge[6] = std::sqrt(temp[0] + temp[1] + temp[2]);
+  edge[6] = sqrt(temp[0] + temp[1] + temp[2]);
 
   for (i = 0; i < 3; i++)
   {
     temp[i] = coordinates[4][i] - coordinates[7][i];
     temp[i] = temp[i] * temp[i];
   }
-  edge[7] = std::sqrt(temp[0] + temp[1] + temp[2]);
+  edge[7] = sqrt(temp[0] + temp[1] + temp[2]);
 
   for (i = 0; i < 3; i++)
   {
     temp[i] = coordinates[4][i] - coordinates[0][i];
     temp[i] = temp[i] * temp[i];
   }
-  edge[8] = std::sqrt(temp[0] + temp[1] + temp[2]);
+  edge[8] = sqrt(temp[0] + temp[1] + temp[2]);
 
   for (i = 0; i < 3; i++)
   {
     temp[i] = coordinates[5][i] - coordinates[1][i];
     temp[i] = temp[i] * temp[i];
   }
-  edge[9] = std::sqrt(temp[0] + temp[1] + temp[2]);
+  edge[9] = sqrt(temp[0] + temp[1] + temp[2]);
 
   for (i = 0; i < 3; i++)
   {
     temp[i] = coordinates[6][i] - coordinates[2][i];
     temp[i] = temp[i] * temp[i];
   }
-  edge[10] = std::sqrt(temp[0] + temp[1] + temp[2]);
+  edge[10] = sqrt(temp[0] + temp[1] + temp[2]);
 
   for (i = 0; i < 3; i++)
   {
     temp[i] = coordinates[7][i] - coordinates[3][i];
     temp[i] = temp[i] * temp[i];
   }
-  edge[11] = std::sqrt(temp[0] + temp[1] + temp[2]);
+  edge[11] = sqrt(temp[0] + temp[1] + temp[2]);
 
   double _edge = edge[0];
 
@@ -558,7 +660,7 @@ static double hex_edge_length(int max_min, const double coordinates[][3])
   {
     for (i = 1; i < 12; i++)
     {
-      _edge = std::min(_edge, edge[i]);
+      _edge = fmin(_edge, edge[i]);
     }
     return _edge;
   }
@@ -566,13 +668,13 @@ static double hex_edge_length(int max_min, const double coordinates[][3])
   {
     for (i = 1; i < 12; i++)
     {
-      _edge = std::max(_edge, edge[i]);
+      _edge = fmax(_edge, edge[i]);
     }
     return _edge;
   }
 }
 
-static double diag_length(int max_min, const double coordinates[][3])
+VERDICT_HOST_DEVICE static double diag_length(int max_min, const double coordinates[][3])
 {
   double temp[3], diag[4];
   int i;
@@ -583,35 +685,35 @@ static double diag_length(int max_min, const double coordinates[][3])
     temp[i] = coordinates[6][i] - coordinates[0][i];
     temp[i] = temp[i] * temp[i];
   }
-  diag[0] = std::sqrt(temp[0] + temp[1] + temp[2]);
+  diag[0] = sqrt(temp[0] + temp[1] + temp[2]);
 
   for (i = 0; i < 3; i++)
   {
     temp[i] = coordinates[4][i] - coordinates[2][i];
     temp[i] = temp[i] * temp[i];
   }
-  diag[1] = std::sqrt(temp[0] + temp[1] + temp[2]);
+  diag[1] = sqrt(temp[0] + temp[1] + temp[2]);
 
   for (i = 0; i < 3; i++)
   {
     temp[i] = coordinates[7][i] - coordinates[1][i];
     temp[i] = temp[i] * temp[i];
   }
-  diag[2] = std::sqrt(temp[0] + temp[1] + temp[2]);
+  diag[2] = sqrt(temp[0] + temp[1] + temp[2]);
 
   for (i = 0; i < 3; i++)
   {
     temp[i] = coordinates[5][i] - coordinates[3][i];
     temp[i] = temp[i] * temp[i];
   }
-  diag[3] = std::sqrt(temp[0] + temp[1] + temp[2]);
+  diag[3] = sqrt(temp[0] + temp[1] + temp[2]);
 
   double diagonal = diag[0];
   if (max_min == 0) // Return min diagonal
   {
     for (i = 1; i < 4; i++)
     {
-      diagonal = std::min(diagonal, diag[i]);
+      diagonal = fmin(diagonal, diag[i]);
     }
     return diagonal;
   }
@@ -619,14 +721,14 @@ static double diag_length(int max_min, const double coordinates[][3])
   {
     for (i = 1; i < 4; i++)
     {
-      diagonal = std::max(diagonal, diag[i]);
+      diagonal = fmax(diagonal, diag[i]);
     }
     return diagonal;
   }
 }
 
 //! calculates efg values
-static VerdictVector calc_hex_efg(int efg_index, VerdictVector coordinates[8])
+VERDICT_HOST_DEVICE static VerdictVector calc_hex_efg(int efg_index, VerdictVector coordinates[8])
 {
 
   VerdictVector efg;
@@ -723,7 +825,7 @@ static VerdictVector calc_hex_efg(int efg_index, VerdictVector coordinates[8])
      Hmax / Hmin where Hmax and Hmin are respectively the maximum and the
      minimum edge lengths
  */
-double hex_edge_ratio(int /*num_nodes*/, const double coordinates[][3])
+VERDICT_HOST_DEVICE double hex_edge_ratio(int /*num_nodes*/, const double coordinates[][3])
 {
   VerdictVector edges[12];
   make_hex_edges(coordinates, edges);
@@ -828,13 +930,13 @@ double hex_edge_ratio(int /*num_nodes*/, const double coordinates[][3])
   M2 = Mab > Mcd ? Mab : Mcd;
   M2 = M2 > Mef ? M2 : Mef;
 
-  double edge_ratio = std::sqrt(M2 / m2);
+  double edge_ratio = sqrt(M2 / m2);
 
   if (edge_ratio > 0)
   {
-    return (double)std::min(edge_ratio, VERDICT_DBL_MAX);
+    return fmin(edge_ratio, VERDICT_DBL_MAX);
   }
-  return (double)std::max(edge_ratio, -VERDICT_DBL_MAX);
+  return fmax(edge_ratio, -VERDICT_DBL_MAX);
 }
 
 /*!
@@ -842,7 +944,7 @@ double hex_edge_ratio(int /*num_nodes*/, const double coordinates[][3])
 
   Maximum edge length ratio at hex center
  */
-double hex_max_edge_ratio(int /*num_nodes*/, const double coordinates[][3])
+VERDICT_HOST_DEVICE double hex_max_edge_ratio(int /*num_nodes*/, const double coordinates[][3])
 {
   double aspect;
   VerdictVector node_pos[8];
@@ -858,20 +960,20 @@ double hex_max_edge_ratio(int /*num_nodes*/, const double coordinates[][3])
   double mag_efg2 = efg2.length();
   double mag_efg3 = efg3.length();
 
-  aspect_12 = safe_ratio(std::max(mag_efg1, mag_efg2), std::min(mag_efg1, mag_efg2));
-  aspect_13 = safe_ratio(std::max(mag_efg1, mag_efg3), std::min(mag_efg1, mag_efg3));
-  aspect_23 = safe_ratio(std::max(mag_efg2, mag_efg3), std::min(mag_efg2, mag_efg3));
+  aspect_12 = safe_ratio(fmax(mag_efg1, mag_efg2), fmin(mag_efg1, mag_efg2));
+  aspect_13 = safe_ratio(fmax(mag_efg1, mag_efg3), fmin(mag_efg1, mag_efg3));
+  aspect_23 = safe_ratio(fmax(mag_efg2, mag_efg3), fmin(mag_efg2, mag_efg3));
 
-  aspect = std::max({ aspect_12, aspect_13, aspect_23 });
+  aspect = fmax(aspect_12, fmax(aspect_13, aspect_23));
 
   if (aspect > 0)
   {
-    return (double)std::min(aspect, VERDICT_DBL_MAX);
+    return fmin(aspect, VERDICT_DBL_MAX);
   }
-  return (double)std::max(aspect, -VERDICT_DBL_MAX);
+  return fmax(aspect, -VERDICT_DBL_MAX);
 }
 
-double hex_equiangle_skew(int /*num_nodes*/, const double coordinates[][3])
+VERDICT_HOST_DEVICE double hex_equiangle_skew(int /*num_nodes*/, const double coordinates[][3])
 {
   double quad[4][3];
   double min_angle = 360.0;
@@ -1031,7 +1133,7 @@ double hex_equiangle_skew(int /*num_nodes*/, const double coordinates[][3])
 
   Maximum ||cosA|| where A is the angle between edges at hex center.
  */
-double hex_skew(int /*num_nodes*/, const double coordinates[][3])
+VERDICT_HOST_DEVICE double hex_skew(int /*num_nodes*/, const double coordinates[][3])
 {
   VerdictVector node_pos[8];
   make_hex_nodes(coordinates, node_pos);
@@ -1055,17 +1157,17 @@ double hex_skew(int /*num_nodes*/, const double coordinates[][3])
     return VERDICT_DBL_MAX;
   }
 
-  skew_1 = std::abs(VerdictVector::Dot(efg1, efg2));
-  skew_2 = std::abs(VerdictVector::Dot(efg1, efg3));
-  skew_3 = std::abs(VerdictVector::Dot(efg2, efg3));
+  skew_1 = fabs(VerdictVector::Dot(efg1, efg2));
+  skew_2 = fabs(VerdictVector::Dot(efg1, efg3));
+  skew_3 = fabs(VerdictVector::Dot(efg2, efg3));
 
-  double skew = std::max({ skew_1, skew_2, skew_3 });
+  double skew = fmax(skew_1, fmax(skew_2, skew_3));
 
   if (skew > 0)
   {
-    return (double)std::min(skew, VERDICT_DBL_MAX);
+    return fmin(skew, VERDICT_DBL_MAX);
   }
-  return (double)std::max(skew, -VERDICT_DBL_MAX);
+  return fmax(skew, -VERDICT_DBL_MAX);
 }
 
 /*!
@@ -1073,7 +1175,7 @@ double hex_skew(int /*num_nodes*/, const double coordinates[][3])
 
   Maximum ratio of lengths derived from opposite edges.
  */
-double hex_taper(int /*num_nodes*/, const double coordinates[][3])
+VERDICT_HOST_DEVICE double hex_taper(int /*num_nodes*/, const double coordinates[][3])
 {
   VerdictVector node_pos[8];
   make_hex_nodes(coordinates, node_pos);
@@ -1086,17 +1188,17 @@ double hex_taper(int /*num_nodes*/, const double coordinates[][3])
   VerdictVector efg13 = calc_hex_efg(13, node_pos);
   VerdictVector efg23 = calc_hex_efg(23, node_pos);
 
-  double taper_1 = std::abs(safe_ratio(efg12.length(), std::min(efg1.length(), efg2.length())));
-  double taper_2 = std::abs(safe_ratio(efg13.length(), std::min(efg1.length(), efg3.length())));
-  double taper_3 = std::abs(safe_ratio(efg23.length(), std::min(efg2.length(), efg3.length())));
+  double taper_1 = fabs(safe_ratio(efg12.length(), fmin(efg1.length(), efg2.length())));
+  double taper_2 = fabs(safe_ratio(efg13.length(), fmin(efg1.length(), efg3.length())));
+  double taper_3 = fabs(safe_ratio(efg23.length(), fmin(efg2.length(), efg3.length())));
 
-  double taper = std::max({ taper_1, taper_2, taper_3 });
+  double taper = fmax(taper_1, fmax(taper_2, taper_3));
 
   if (taper > 0)
   {
-    return (double)std::min(taper, VERDICT_DBL_MAX);
+    return fmin(taper, VERDICT_DBL_MAX);
   }
-  return (double)std::max(taper, -VERDICT_DBL_MAX);
+  return fmax(taper, -VERDICT_DBL_MAX);
 }
 
 /*!
@@ -1104,23 +1206,21 @@ double hex_taper(int /*num_nodes*/, const double coordinates[][3])
   Split the hex into 24 tets.
   sum the volume of each tet.
  */
-double hex_volume(int num_nodes, const double coordinates[][3])
+VERDICT_HOST_DEVICE double hex_volume(int num_nodes, const double coordinates[][3])
 {
   double volume = 0.0;
 
   if (num_nodes > 9)
   {
-    int(*subtet_conn_array)[4];
     int num_subtets = 0;
+
     if (27 == num_nodes)
     {
       num_subtets = 48;
-      subtet_conn_array = hex27_subtet_conn;
     }
     else if (20 == num_nodes)
     {
       num_subtets = 36;
-      subtet_conn_array = hex20_subtet_conn;
     }
     else
     {
@@ -1131,19 +1231,30 @@ double hex_volume(int num_nodes, const double coordinates[][3])
 
     for (int k = 0; k < num_subtets; k++)
     {
+      const int* subtet_conn;
+
+      if (27 == num_nodes)
+      {
+        subtet_conn = hex27_subtet_conn(k);
+      }
+      else if (20 == num_nodes)
+      {
+        subtet_conn = hex20_subtet_conn(k);
+      }
+
       VerdictVector v1(
-        coordinates[subtet_conn_array[k][1]][0] - coordinates[subtet_conn_array[k][0]][0],
-        coordinates[subtet_conn_array[k][1]][1] - coordinates[subtet_conn_array[k][0]][1],
-        coordinates[subtet_conn_array[k][1]][2] - coordinates[subtet_conn_array[k][0]][2]);
+        coordinates[subtet_conn[1]][0] - coordinates[subtet_conn[0]][0],
+        coordinates[subtet_conn[1]][1] - coordinates[subtet_conn[0]][1],
+        coordinates[subtet_conn[1]][2] - coordinates[subtet_conn[0]][2]);
 
       VerdictVector v2(
-        coordinates[subtet_conn_array[k][2]][0] - coordinates[subtet_conn_array[k][0]][0],
-        coordinates[subtet_conn_array[k][2]][1] - coordinates[subtet_conn_array[k][0]][1],
-        coordinates[subtet_conn_array[k][2]][2] - coordinates[subtet_conn_array[k][0]][2]);
+        coordinates[subtet_conn[2]][0] - coordinates[subtet_conn[0]][0],
+        coordinates[subtet_conn[2]][1] - coordinates[subtet_conn[0]][1],
+        coordinates[subtet_conn[2]][2] - coordinates[subtet_conn[0]][2]);
 
-      VerdictVector v3(aux_node.x() - coordinates[subtet_conn_array[k][0]][0],
-        aux_node.y() - coordinates[subtet_conn_array[k][0]][1],
-        aux_node.z() - coordinates[subtet_conn_array[k][0]][2]);
+      VerdictVector v3(aux_node.x() - coordinates[subtet_conn[0]][0],
+        aux_node.y() - coordinates[subtet_conn[0]][1],
+        aux_node.z() - coordinates[subtet_conn[0]][2]);
 
       volume += compute_tet_volume(v1, v2, v3);
     }
@@ -1204,9 +1315,9 @@ double hex_volume(int num_nodes, const double coordinates[][3])
 
   if (volume > 0)
   {
-    return (double)std::min(volume, VERDICT_DBL_MAX);
+    return fmin(volume, VERDICT_DBL_MAX);
   }
-  return (double)std::max(volume, -VERDICT_DBL_MAX);
+  return fmax(volume, -VERDICT_DBL_MAX);
 }
 
 /*!
@@ -1214,18 +1325,18 @@ double hex_volume(int num_nodes, const double coordinates[][3])
 
   sqrt(3) * minimum edge length / maximum diagonal length
  */
-double hex_stretch(int /*num_nodes*/, const double coordinates[][3])
+VERDICT_HOST_DEVICE double hex_stretch(int /*num_nodes*/, const double coordinates[][3])
 {
   double min_edge = hex_edge_length(0, coordinates);
   double max_diag = diag_length(1, coordinates);
 
-  double stretch = sqrt3 * safe_ratio(min_edge, max_diag);
+  double stretch = sqrt(3.0) * safe_ratio(min_edge, max_diag);
 
   if (stretch > 0)
   {
-    return (double)std::min(stretch, VERDICT_DBL_MAX);
+    return fmin(stretch, VERDICT_DBL_MAX);
   }
-  return (double)std::max(stretch, -VERDICT_DBL_MAX);
+  return fmax(stretch, -VERDICT_DBL_MAX);
 }
 
 /*!
@@ -1233,7 +1344,7 @@ double hex_stretch(int /*num_nodes*/, const double coordinates[][3])
 
   Minimum diagonal length / maximum diagonal length
  */
-double hex_diagonal(int /*num_nodes*/, const double coordinates[][3])
+VERDICT_HOST_DEVICE double hex_diagonal(int /*num_nodes*/, const double coordinates[][3])
 {
   double min_diag = diag_length(0, coordinates);
   double max_diag = diag_length(1, coordinates);
@@ -1242,9 +1353,9 @@ double hex_diagonal(int /*num_nodes*/, const double coordinates[][3])
 
   if (diagonal > 0)
   {
-    return (double)std::min(diagonal, VERDICT_DBL_MAX);
+    return fmin(diagonal, VERDICT_DBL_MAX);
   }
-  return (double)std::max(diagonal, -VERDICT_DBL_MAX);
+  return fmax(diagonal, -VERDICT_DBL_MAX);
 }
 
 #define SQR(x) ((x) * (x))
@@ -1255,7 +1366,7 @@ double hex_diagonal(int /*num_nodes*/, const double coordinates[][3])
   Pronto-specific characteristic length for stable time step calculation.
   Char_length = Volume / 2 grad Volume
 */
-double hex_dimension(int /*num_nodes*/, const double coordinates[][3])
+VERDICT_HOST_DEVICE double hex_dimension(int /*num_nodes*/, const double coordinates[][3])
 {
   double gradop[9][4];
 
@@ -1469,7 +1580,7 @@ double hex_dimension(int /*num_nodes*/, const double coordinates[][3])
       SQR(gradop[1][3]) + SQR(gradop[2][3]) + SQR(gradop[3][3]) + SQR(gradop[4][3]) +
       SQR(gradop[5][3]) + SQR(gradop[6][3]) + SQR(gradop[7][3]) + SQR(gradop[8][3]));
 
-  return (double)std::sqrt(aspect);
+  return (double)sqrt(aspect);
 }
 
 /*!
@@ -1477,7 +1588,7 @@ double hex_dimension(int /*num_nodes*/, const double coordinates[][3])
 
   General distortion measure based on left Cauchy-Green Tensor
  */
-double hex_oddy(int /*num_nodes*/, const double coordinates[][3])
+VERDICT_HOST_DEVICE double hex_oddy(int /*num_nodes*/, const double coordinates[][3])
 {
   double oddy = 0.0, current_oddy;
   VerdictVector xxi, xet, xze;
@@ -1617,9 +1728,9 @@ double hex_oddy(int /*num_nodes*/, const double coordinates[][3])
 
   if (oddy > 0)
   {
-    return (double)std::min(oddy, VERDICT_DBL_MAX);
+    return fmin(oddy, VERDICT_DBL_MAX);
   }
-  return (double)std::max(oddy, -VERDICT_DBL_MAX);
+  return fmax(oddy, -VERDICT_DBL_MAX);
 }
 
 /*!
@@ -1629,7 +1740,7 @@ double hex_oddy(int /*num_nodes*/, const double coordinates[][3])
      this function is calculated by averaging the 8 Frobenius aspects at
      each corner of the hex, when the reference corner is right isosceles.
  */
-double hex_med_aspect_frobenius(int /*num_nodes*/, const double coordinates[][3])
+VERDICT_HOST_DEVICE double hex_med_aspect_frobenius(int /*num_nodes*/, const double coordinates[][3])
 {
   VerdictVector node_pos[8];
   make_hex_nodes(coordinates, node_pos);
@@ -1712,7 +1823,7 @@ double hex_med_aspect_frobenius(int /*num_nodes*/, const double coordinates[][3]
      this function is calculated by taking the maximum of the 8 Frobenius aspects at
      each corner of the hex, when the reference corner is right isosceles.
  */
-double hex_max_aspect_frobenius(int /*num_nodes*/, const double coordinates[][3])
+VERDICT_HOST_DEVICE double hex_max_aspect_frobenius(int /*num_nodes*/, const double coordinates[][3])
 {
   VerdictVector node_pos[8];
   make_hex_nodes(coordinates, node_pos);
@@ -1822,7 +1933,7 @@ double hex_max_aspect_frobenius(int /*num_nodes*/, const double coordinates[][3]
      It will become deprecated at some point.
 
  */
-double hex_condition(int /*num_nodes*/, const double coordinates[][3])
+VERDICT_HOST_DEVICE double hex_condition(int /*num_nodes*/, const double coordinates[][3])
 {
   return hex_max_aspect_frobenius(8, coordinates);
 }
@@ -1832,7 +1943,7 @@ double hex_condition(int /*num_nodes*/, const double coordinates[][3])
 
   Minimum pointwise volume of local map at 8 corners & center of hex
  */
-double hex_jacobian(int num_nodes, const double coordinates[][3])
+VERDICT_HOST_DEVICE double hex_jacobian(int num_nodes, const double coordinates[][3])
 {
   if (num_nodes == 27)
   {
@@ -1843,7 +1954,7 @@ double hex_jacobian(int num_nodes, const double coordinates[][3])
 
     for (int i = 0; i < 27; i++)
     {
-      HEX27_gradients_of_the_shape_functions_for_RST(HEX27_node_local_coord[i], dhdr, dhds, dhdt);
+      HEX27_gradients_of_the_shape_functions_for_RST(HEX27_node_local_coord(i), dhdr, dhds, dhdt);
       double jacobian[3][3] = { { 0, 0, 0 }, { 0, 0, 0 }, { 0, 0, 0 } };
 
       for (int j = 0; j < 27; j++)
@@ -1860,7 +1971,7 @@ double hex_jacobian(int num_nodes, const double coordinates[][3])
       }
       double det = VerdictVector::Dot(
         (VerdictVector(jacobian[0]) * VerdictVector(jacobian[1])), VerdictVector(jacobian[2]));
-      min_determinant = std::min(det, min_determinant);
+      min_determinant = fmin(det, min_determinant);
     }
     return min_determinant;
   }
@@ -1973,9 +2084,9 @@ double hex_jacobian(int num_nodes, const double coordinates[][3])
 
     if (jacobian > 0)
     {
-      return (double)std::min(jacobian, VERDICT_DBL_MAX);
+      return fmin(jacobian, VERDICT_DBL_MAX);
     }
-    return (double)std::max(jacobian, -VERDICT_DBL_MAX);
+    return fmax(jacobian, -VERDICT_DBL_MAX);
   }
 }
 
@@ -1984,7 +2095,7 @@ double hex_jacobian(int num_nodes, const double coordinates[][3])
 
   Minimum Jacobian divided by the lengths of the 3 edge vectors
  */
-double hex_scaled_jacobian(int num_nodes, const double coordinates[][3])
+VERDICT_HOST_DEVICE double hex_scaled_jacobian(int num_nodes, const double coordinates[][3])
 {
   double jacobi, min_norm_jac = VERDICT_DBL_MAX;
 
@@ -1997,7 +2108,7 @@ double hex_scaled_jacobian(int num_nodes, const double coordinates[][3])
 
     for(int i=0; i<27; i++)
     {
-      HEX27_gradients_of_the_shape_functions_for_RST(HEX27_node_local_coord[i], dhdr, dhds, dhdt);
+      HEX27_gradients_of_the_shape_functions_for_RST(HEX27_node_local_coord(i), dhdr, dhds, dhdt);
       double jacobian[3][3] = {{0,0,0},{0,0,0},{0,0,0}};
 
       for(int j=0; j<27; j++)
@@ -2016,7 +2127,7 @@ double hex_scaled_jacobian(int num_nodes, const double coordinates[][3])
       VerdictVector xet(jacobian[1]);
       VerdictVector xze(jacobian[2]);
       jacobi = xxi % ( xet * xze );
-      double scale = std::sqrt(xxi.length_squared() * xet.length_squared() * xze.length_squared());
+      double scale = sqrt(xxi.length_squared() * xet.length_squared() * xze.length_squared());
       jacobi /= scale;
       if(jacobi < min_norm_jac)
       {
@@ -2054,7 +2165,7 @@ double hex_scaled_jacobian(int num_nodes, const double coordinates[][3])
       return (double)VERDICT_DBL_MAX;
     }
 
-    lengths = std::sqrt(len1_sq * len2_sq * len3_sq);
+    lengths = sqrt(len1_sq * len2_sq * len3_sq);
     temp_norm_jac = jacobi / lengths;
 
     if (temp_norm_jac < min_norm_jac)
@@ -2086,7 +2197,7 @@ double hex_scaled_jacobian(int num_nodes, const double coordinates[][3])
       return (double)VERDICT_DBL_MAX;
     }
 
-    lengths = std::sqrt(len1_sq * len2_sq * len3_sq);
+    lengths = sqrt(len1_sq * len2_sq * len3_sq);
     temp_norm_jac = jacobi / lengths;
     if (temp_norm_jac < min_norm_jac)
     {
@@ -2117,7 +2228,7 @@ double hex_scaled_jacobian(int num_nodes, const double coordinates[][3])
       return (double)VERDICT_DBL_MAX;
     }
 
-    lengths = std::sqrt(len1_sq * len2_sq * len3_sq);
+    lengths = sqrt(len1_sq * len2_sq * len3_sq);
     temp_norm_jac = jacobi / lengths;
     if (temp_norm_jac < min_norm_jac)
     {
@@ -2148,7 +2259,7 @@ double hex_scaled_jacobian(int num_nodes, const double coordinates[][3])
       return (double)VERDICT_DBL_MAX;
     }
 
-    lengths = std::sqrt(len1_sq * len2_sq * len3_sq);
+    lengths = sqrt(len1_sq * len2_sq * len3_sq);
     temp_norm_jac = jacobi / lengths;
     if (temp_norm_jac < min_norm_jac)
     {
@@ -2179,7 +2290,7 @@ double hex_scaled_jacobian(int num_nodes, const double coordinates[][3])
       return (double)VERDICT_DBL_MAX;
     }
 
-    lengths = std::sqrt(len1_sq * len2_sq * len3_sq);
+    lengths = sqrt(len1_sq * len2_sq * len3_sq);
     temp_norm_jac = jacobi / lengths;
     if (temp_norm_jac < min_norm_jac)
     {
@@ -2210,7 +2321,7 @@ double hex_scaled_jacobian(int num_nodes, const double coordinates[][3])
       return (double)VERDICT_DBL_MAX;
     }
 
-    lengths = std::sqrt(len1_sq * len2_sq * len3_sq);
+    lengths = sqrt(len1_sq * len2_sq * len3_sq);
     temp_norm_jac = jacobi / lengths;
     if (temp_norm_jac < min_norm_jac)
     {
@@ -2241,7 +2352,7 @@ double hex_scaled_jacobian(int num_nodes, const double coordinates[][3])
       return (double)VERDICT_DBL_MAX;
     }
 
-    lengths = std::sqrt(len1_sq * len2_sq * len3_sq);
+    lengths = sqrt(len1_sq * len2_sq * len3_sq);
     temp_norm_jac = jacobi / lengths;
     if (temp_norm_jac < min_norm_jac)
     {
@@ -2272,7 +2383,7 @@ double hex_scaled_jacobian(int num_nodes, const double coordinates[][3])
       return (double)VERDICT_DBL_MAX;
     }
 
-    lengths = std::sqrt(len1_sq * len2_sq * len3_sq);
+    lengths = sqrt(len1_sq * len2_sq * len3_sq);
     temp_norm_jac = jacobi / lengths;
     if (temp_norm_jac < min_norm_jac)
     {
@@ -2303,7 +2414,7 @@ double hex_scaled_jacobian(int num_nodes, const double coordinates[][3])
       return (double)VERDICT_DBL_MAX;
     }
 
-    lengths = std::sqrt(len1_sq * len2_sq * len3_sq);
+    lengths = sqrt(len1_sq * len2_sq * len3_sq);
     temp_norm_jac = jacobi / lengths;
     if (temp_norm_jac < min_norm_jac)
     {
@@ -2317,49 +2428,36 @@ double hex_scaled_jacobian(int num_nodes, const double coordinates[][3])
 
   if (min_norm_jac > 0)
   {
-    return (double)std::min(min_norm_jac, VERDICT_DBL_MAX);
+    return fmin(min_norm_jac, VERDICT_DBL_MAX);
   }
-  return (double)std::max(min_norm_jac, -VERDICT_DBL_MAX);
+  return fmax(min_norm_jac, -VERDICT_DBL_MAX);
 }
 
 /*!
   Nodal jacobian ratio of a hex
   Minimum nodal jacobian divided by the maximum.  Detects element skewness.
  */
-inline std::pair<double /*min*/, double /*max*/> minMaxVal(const double a1, const double a2)
-{
-  return (a1 < a2) ? std::pair<double, double>(a1, a2) : std::pair<double, double>(a2, a1);
-}
-
-inline std::pair<double, double> minMaxValPair(
-  const std::pair<double, double>& a1, const std::pair<double, double>& a2)
-{
-  return std::pair<double, double>(std::min(a1.first, a2.first), std::max(a1.second, a2.second));
-}
-
-double hex_nodal_jacobian_ratio(int num_nodes, const double coordinates[][3])
+VERDICT_HOST_DEVICE double hex_nodal_jacobian_ratio(int num_nodes, const double coordinates[][3])
 {
   return verdict::hex_nodal_jacobian_ratio2(num_nodes, (double*)coordinates);
 }
 
-double hex_nodal_jacobian_ratio2(int /*num_nodes*/, const double* coordinates)
+VERDICT_HOST_DEVICE double hex_nodal_jacobian_ratio2(int /*num_nodes*/, const double* coordinates)
 {
   double Jdet8x[8];
   verdict::hex_nodal_jacobians(coordinates, Jdet8x);
+
   //
-  //  Compute the minimum and maximum nodal determinates, use an optimal algorithm
+  //  Compute the minimum and maximum nodal determinates.
   //
-  // std::pair<double, double> minMaxResult = std::minmax_element(Jdet8x, Jdet8x+8);
 
-  std::pair<double, double> m01(minMaxVal(Jdet8x[0], Jdet8x[1]));
-  std::pair<double, double> m23(minMaxVal(Jdet8x[2], Jdet8x[3]));
-  std::pair<double, double> m45(minMaxVal(Jdet8x[4], Jdet8x[5]));
-  std::pair<double, double> m67(minMaxVal(Jdet8x[6], Jdet8x[7]));
+  double minVal = VERDICT_DBL_MAX;
+  double maxVal = -VERDICT_DBL_MAX;
 
-  std::pair<double, double> m0123(minMaxValPair(m01, m23));
-  std::pair<double, double> m4567(minMaxValPair(m45, m67));
-
-  std::pair<double, double> m01234567(minMaxValPair(m0123, m4567));
+  for (int i = 0; i < 8; ++i) {
+     minVal = fmin(minVal, Jdet8x[i]);
+     maxVal = fmax(maxVal, Jdet8x[i]);
+  }
 
   //
   //  Turn the determinates into a normalized quality ratio.
@@ -2367,13 +2465,13 @@ double hex_nodal_jacobian_ratio2(int /*num_nodes*/, const double* coordinates)
   //  number Otherwise return ratio of the minimal nodal determinate to the maximum
   //
 
-  if (m01234567.second <= VERDICT_DBL_MIN)
+  if (maxVal <= VERDICT_DBL_MIN)
   {
     return -VERDICT_DBL_MAX;
   }
   else
   {
-    return m01234567.first / m01234567.second;
+    return minVal / maxVal;
   }
 }
 
@@ -2382,7 +2480,7 @@ double hex_nodal_jacobian_ratio2(int /*num_nodes*/, const double* coordinates)
 
   3/Condition number of Jacobian Skew matrix
  */
-double hex_shear(int /*num_nodes*/, const double coordinates[][3])
+VERDICT_HOST_DEVICE double hex_shear(int /*num_nodes*/, const double coordinates[][3])
 {
   double shear;
   double min_shear = 1.0;
@@ -2406,7 +2504,7 @@ double hex_shear(int /*num_nodes*/, const double coordinates[][3])
     return 0;
   }
 
-  lengths = std::sqrt(len1_sq * len2_sq * len3_sq);
+  lengths = sqrt(len1_sq * len2_sq * len3_sq);
   det = VerdictVector::Dot(xxi, (xet * xze));
   if (det < VERDICT_DBL_MIN)
   {
@@ -2414,7 +2512,7 @@ double hex_shear(int /*num_nodes*/, const double coordinates[][3])
   }
 
   shear = det / lengths;
-  min_shear = std::min(shear, min_shear);
+  min_shear = fmin(shear, min_shear);
 
   // J(1,0,0):
   xxi = node_pos[2] - node_pos[1];
@@ -2430,7 +2528,7 @@ double hex_shear(int /*num_nodes*/, const double coordinates[][3])
     return 0;
   }
 
-  lengths = std::sqrt(len1_sq * len2_sq * len3_sq);
+  lengths = sqrt(len1_sq * len2_sq * len3_sq);
   det = VerdictVector::Dot(xxi, (xet * xze));
   if (det < VERDICT_DBL_MIN)
   {
@@ -2438,7 +2536,7 @@ double hex_shear(int /*num_nodes*/, const double coordinates[][3])
   }
 
   shear = det / lengths;
-  min_shear = std::min(shear, min_shear);
+  min_shear = fmin(shear, min_shear);
 
   // J(1,1,0):
   xxi = node_pos[3] - node_pos[2];
@@ -2454,7 +2552,7 @@ double hex_shear(int /*num_nodes*/, const double coordinates[][3])
     return 0;
   }
 
-  lengths = std::sqrt(len1_sq * len2_sq * len3_sq);
+  lengths = sqrt(len1_sq * len2_sq * len3_sq);
   det = VerdictVector::Dot(xxi, (xet * xze));
   if (det < VERDICT_DBL_MIN)
   {
@@ -2462,7 +2560,7 @@ double hex_shear(int /*num_nodes*/, const double coordinates[][3])
   }
 
   shear = det / lengths;
-  min_shear = std::min(shear, min_shear);
+  min_shear = fmin(shear, min_shear);
 
   // J(0,1,0):
   xxi = node_pos[0] - node_pos[3];
@@ -2478,7 +2576,7 @@ double hex_shear(int /*num_nodes*/, const double coordinates[][3])
     return 0;
   }
 
-  lengths = std::sqrt(len1_sq * len2_sq * len3_sq);
+  lengths = sqrt(len1_sq * len2_sq * len3_sq);
   det = VerdictVector::Dot(xxi, (xet * xze));
   if (det < VERDICT_DBL_MIN)
   {
@@ -2486,7 +2584,7 @@ double hex_shear(int /*num_nodes*/, const double coordinates[][3])
   }
 
   shear = det / lengths;
-  min_shear = std::min(shear, min_shear);
+  min_shear = fmin(shear, min_shear);
 
   // J(0,0,1):
   xxi = node_pos[7] - node_pos[4];
@@ -2502,7 +2600,7 @@ double hex_shear(int /*num_nodes*/, const double coordinates[][3])
     return 0;
   }
 
-  lengths = std::sqrt(len1_sq * len2_sq * len3_sq);
+  lengths = sqrt(len1_sq * len2_sq * len3_sq);
   det = VerdictVector::Dot(xxi, (xet * xze));
   if (det < VERDICT_DBL_MIN)
   {
@@ -2510,7 +2608,7 @@ double hex_shear(int /*num_nodes*/, const double coordinates[][3])
   }
 
   shear = det / lengths;
-  min_shear = std::min(shear, min_shear);
+  min_shear = fmin(shear, min_shear);
 
   // J(1,0,1):
   xxi = node_pos[4] - node_pos[5];
@@ -2526,7 +2624,7 @@ double hex_shear(int /*num_nodes*/, const double coordinates[][3])
     return 0;
   }
 
-  lengths = std::sqrt(len1_sq * len2_sq * len3_sq);
+  lengths = sqrt(len1_sq * len2_sq * len3_sq);
   det = VerdictVector::Dot(xxi, (xet * xze));
   if (det < VERDICT_DBL_MIN)
   {
@@ -2534,7 +2632,7 @@ double hex_shear(int /*num_nodes*/, const double coordinates[][3])
   }
 
   shear = det / lengths;
-  min_shear = std::min(shear, min_shear);
+  min_shear = fmin(shear, min_shear);
 
   // J(1,1,1):
   xxi = node_pos[5] - node_pos[6];
@@ -2550,7 +2648,7 @@ double hex_shear(int /*num_nodes*/, const double coordinates[][3])
     return 0;
   }
 
-  lengths = std::sqrt(len1_sq * len2_sq * len3_sq);
+  lengths = sqrt(len1_sq * len2_sq * len3_sq);
   det = VerdictVector::Dot(xxi, (xet * xze));
   if (det < VERDICT_DBL_MIN)
   {
@@ -2558,7 +2656,7 @@ double hex_shear(int /*num_nodes*/, const double coordinates[][3])
   }
 
   shear = det / lengths;
-  min_shear = std::min(shear, min_shear);
+  min_shear = fmin(shear, min_shear);
 
   // J(0,1,1):
   xxi = node_pos[6] - node_pos[7];
@@ -2574,7 +2672,7 @@ double hex_shear(int /*num_nodes*/, const double coordinates[][3])
     return 0;
   }
 
-  lengths = std::sqrt(len1_sq * len2_sq * len3_sq);
+  lengths = sqrt(len1_sq * len2_sq * len3_sq);
   det = VerdictVector::Dot(xxi, (xet * xze));
   if (det < VERDICT_DBL_MIN)
   {
@@ -2582,7 +2680,7 @@ double hex_shear(int /*num_nodes*/, const double coordinates[][3])
   }
 
   shear = det / lengths;
-  min_shear = std::min(shear, min_shear);
+  min_shear = fmin(shear, min_shear);
 
   if (min_shear <= VERDICT_DBL_MIN)
   {
@@ -2591,9 +2689,9 @@ double hex_shear(int /*num_nodes*/, const double coordinates[][3])
 
   if (min_shear > 0)
   {
-    return (double)std::min(min_shear, VERDICT_DBL_MAX);
+    return fmin(min_shear, VERDICT_DBL_MAX);
   }
-  return (double)std::max(min_shear, -VERDICT_DBL_MAX);
+  return fmax(min_shear, -VERDICT_DBL_MAX);
 }
 
 /*!
@@ -2601,7 +2699,7 @@ double hex_shear(int /*num_nodes*/, const double coordinates[][3])
 
   3/Condition number of weighted Jacobian matrix
  */
-double hex_shape(int /*num_nodes*/, const double coordinates[][3])
+VERDICT_HOST_DEVICE double hex_shape(int /*num_nodes*/, const double coordinates[][3])
 {
   double det, shape;
   double min_shape = 1.0;
@@ -2619,7 +2717,7 @@ double hex_shape(int /*num_nodes*/, const double coordinates[][3])
   det = VerdictVector::Dot(xxi, (xet * xze));
   if (det > VERDICT_DBL_MIN)
   {
-    shape = 3 * std::pow(det, two_thirds) /
+    shape = 3 * pow(det, two_thirds) /
       (VerdictVector::Dot(xxi, xxi) + VerdictVector::Dot(xet, xet) + VerdictVector::Dot(xze, xze));
   }
   else
@@ -2640,7 +2738,7 @@ double hex_shape(int /*num_nodes*/, const double coordinates[][3])
   det = VerdictVector::Dot(xxi, (xet * xze));
   if (det > VERDICT_DBL_MIN)
   {
-    shape = 3 * std::pow(det, two_thirds) /
+    shape = 3 * pow(det, two_thirds) /
       (VerdictVector::Dot(xxi, xxi) + VerdictVector::Dot(xet, xet) + VerdictVector::Dot(xze, xze));
   }
   else
@@ -2661,7 +2759,7 @@ double hex_shape(int /*num_nodes*/, const double coordinates[][3])
   det = VerdictVector::Dot(xxi, (xet * xze));
   if (det > VERDICT_DBL_MIN)
   {
-    shape = 3 * std::pow(det, two_thirds) /
+    shape = 3 * pow(det, two_thirds) /
       (VerdictVector::Dot(xxi, xxi) + VerdictVector::Dot(xet, xet) + VerdictVector::Dot(xze, xze));
   }
   else
@@ -2682,7 +2780,7 @@ double hex_shape(int /*num_nodes*/, const double coordinates[][3])
   det = VerdictVector::Dot(xxi, (xet * xze));
   if (det > VERDICT_DBL_MIN)
   {
-    shape = 3 * std::pow(det, two_thirds) /
+    shape = 3 * pow(det, two_thirds) /
       (VerdictVector::Dot(xxi, xxi) + VerdictVector::Dot(xet, xet) + VerdictVector::Dot(xze, xze));
   }
   else
@@ -2703,7 +2801,7 @@ double hex_shape(int /*num_nodes*/, const double coordinates[][3])
   det = VerdictVector::Dot(xxi, (xet * xze));
   if (det > VERDICT_DBL_MIN)
   {
-    shape = 3 * std::pow(det, two_thirds) /
+    shape = 3 * pow(det, two_thirds) /
       (VerdictVector::Dot(xxi, xxi) + VerdictVector::Dot(xet, xet) + VerdictVector::Dot(xze, xze));
   }
   else
@@ -2724,7 +2822,7 @@ double hex_shape(int /*num_nodes*/, const double coordinates[][3])
   det = VerdictVector::Dot(xxi, (xet * xze));
   if (det > VERDICT_DBL_MIN)
   {
-    shape = 3 * std::pow(det, two_thirds) /
+    shape = 3 * pow(det, two_thirds) /
       (VerdictVector::Dot(xxi, xxi) + VerdictVector::Dot(xet, xet) + VerdictVector::Dot(xze, xze));
   }
   else
@@ -2745,7 +2843,7 @@ double hex_shape(int /*num_nodes*/, const double coordinates[][3])
   det = VerdictVector::Dot(xxi, (xet * xze));
   if (det > VERDICT_DBL_MIN)
   {
-    shape = 3 * std::pow(det, two_thirds) /
+    shape = 3 * pow(det, two_thirds) /
       (VerdictVector::Dot(xxi, xxi) + VerdictVector::Dot(xet, xet) + VerdictVector::Dot(xze, xze));
   }
   else
@@ -2766,7 +2864,7 @@ double hex_shape(int /*num_nodes*/, const double coordinates[][3])
   det = VerdictVector::Dot(xxi, (xet * xze));
   if (det > VERDICT_DBL_MIN)
   {
-    shape = 3 * std::pow(det, two_thirds) /
+    shape = 3 * pow(det, two_thirds) /
       (VerdictVector::Dot(xxi, xxi) + VerdictVector::Dot(xet, xet) + VerdictVector::Dot(xze, xze));
   }
   else
@@ -2786,9 +2884,9 @@ double hex_shape(int /*num_nodes*/, const double coordinates[][3])
 
   if (min_shape > 0)
   {
-    return (double)std::min(min_shape, VERDICT_DBL_MAX);
+    return fmin(min_shape, VERDICT_DBL_MAX);
   }
-  return (double)std::max(min_shape, -VERDICT_DBL_MAX);
+  return fmax(min_shape, -VERDICT_DBL_MAX);
 }
 
 /*!
@@ -2796,7 +2894,7 @@ double hex_shape(int /*num_nodes*/, const double coordinates[][3])
 
   Min( J, 1/J ), where J is determinant of weighted Jacobian matrix
  */
-double hex_relative_size_squared(
+VERDICT_HOST_DEVICE double hex_relative_size_squared(
   int /*num_nodes*/, const double coordinates[][3], double average_hex_volume)
 {
   double size = 0;
@@ -2886,16 +2984,16 @@ double hex_relative_size_squared(
   {
     tau = det_sum / (8 * detw);
 
-    tau = std::min(tau, 1.0 / tau);
+    tau = fmin(tau, 1.0 / tau);
 
     size = tau * tau;
   }
 
   if (size > 0)
   {
-    return (double)std::min(size, VERDICT_DBL_MAX);
+    return fmin(size, VERDICT_DBL_MAX);
   }
-  return (double)std::max(size, -VERDICT_DBL_MAX);
+  return fmax(size, -VERDICT_DBL_MAX);
 }
 
 /*!
@@ -2903,7 +3001,7 @@ double hex_relative_size_squared(
 
   Product of Shape and Relative Size
  */
-double hex_shape_and_size(int num_nodes, const double coordinates[][3], double average_hex_volume)
+VERDICT_HOST_DEVICE double hex_shape_and_size(int num_nodes, const double coordinates[][3], double average_hex_volume)
 {
   double size = hex_relative_size_squared(num_nodes, coordinates, average_hex_volume);
   double shape = hex_shape(num_nodes, coordinates);
@@ -2912,9 +3010,9 @@ double hex_shape_and_size(int num_nodes, const double coordinates[][3], double a
 
   if (shape_size > 0)
   {
-    return (double)std::min(shape_size, VERDICT_DBL_MAX);
+    return fmin(shape_size, VERDICT_DBL_MAX);
   }
-  return (double)std::max(shape_size, -VERDICT_DBL_MAX);
+  return fmax(shape_size, -VERDICT_DBL_MAX);
 }
 
 /*!
@@ -2922,7 +3020,7 @@ double hex_shape_and_size(int num_nodes, const double coordinates[][3], double a
 
   Product of Shear and Relative Size
  */
-double hex_shear_and_size(int num_nodes, const double coordinates[][3], double average_hex_volume)
+VERDICT_HOST_DEVICE double hex_shear_and_size(int num_nodes, const double coordinates[][3], double average_hex_volume)
 {
   double size = hex_relative_size_squared(num_nodes, coordinates, average_hex_volume);
   double shear = hex_shear(num_nodes, coordinates);
@@ -2931,15 +3029,15 @@ double hex_shear_and_size(int num_nodes, const double coordinates[][3], double a
 
   if (shear_size > 0)
   {
-    return (double)std::min(shear_size, VERDICT_DBL_MAX);
+    return fmin(shear_size, VERDICT_DBL_MAX);
   }
-  return (double)std::max(shear_size, -VERDICT_DBL_MAX);
+  return fmax(shear_size, -VERDICT_DBL_MAX);
 }
 
 /*!
   distortion of a hex
  */
-double hex_distortion(int num_nodes, const double coordinates[][3])
+VERDICT_HOST_DEVICE double hex_distortion(int num_nodes, const double coordinates[][3])
 {
   // use 2x2 gauss points for linear hex and 3x3 for 2nd order hex
   int number_of_gauss_points = 0;
@@ -3036,7 +3134,7 @@ double hex_distortion(int num_nodes, const double coordinates[][3])
       minimum_jacobian = jacobian;
     }
   }
-  if (std::abs(element_volume) > 0.0)
+  if (fabs(element_volume) > 0.0)
   {
     distortion = minimum_jacobian / element_volume * 8.;
   }
@@ -3048,26 +3146,26 @@ double hex_distortion(int num_nodes, const double coordinates[][3])
   {
     distortion = -VERDICT_DBL_MAX;
   }
-  else if (std::isnan(distortion))
+  else if (isnan(distortion))
   {
     distortion = VERDICT_DBL_MAX; // 0/0, or should we return some other value?
   }
   return (double)distortion;
 }
 
-double hex_timestep(int num_nodes, const double coordinates[][3], double density,
+VERDICT_HOST_DEVICE double hex_timestep(int num_nodes, const double coordinates[][3], double density,
   double poissons_ratio, double youngs_modulus)
 {
   double char_length = hex_dimension(num_nodes, coordinates);
   double M =
     youngs_modulus * (1 - poissons_ratio) / ((1 - 2 * poissons_ratio) * (1 + poissons_ratio));
-  double denominator = std::sqrt(M / density);
+  double denominator = sqrt(M / density);
 
   return char_length / denominator;
 }
 
 /*
-double hex_jac_normjac_oddy_cond( int choices[],
+VERDICT_HOST_DEVICE double hex_jac_normjac_oddy_cond( int choices[],
                       const double coordinates[][3],
                       double answers[4]  )
 {

--- a/V_HexMetric.hpp
+++ b/V_HexMetric.hpp
@@ -23,16 +23,13 @@
 
 #include "verdict.h"
 
-#include <cassert>
-#include <cmath>
-
 namespace VERDICT_NAMESPACE
 {
 //
 //  Compute jacobian at each of the eight hex corner nodes
 //
 template <typename T>
-void hex_nodal_jacobians(const T coords[24], T Jdet8x[8])
+VERDICT_HOST_DEVICE void hex_nodal_jacobians(const T coords[24], T Jdet8x[8])
 {
   T x0 = coords[0];
   T y0 = coords[1];

--- a/V_KnifeMetric.cpp
+++ b/V_KnifeMetric.cpp
@@ -50,7 +50,7 @@ namespace VERDICT_NAMESPACE
   this is done by dividing the knife into 4 tets
   and summing the volumes of each.
  */
-double knife_volume(int num_nodes, const double coordinates[][3])
+VERDICT_HOST_DEVICE double knife_volume(int num_nodes, const double coordinates[][3])
 {
   double volume = 0;
   VerdictVector side1, side2, side3;

--- a/V_QuadMetric.cpp
+++ b/V_QuadMetric.cpp
@@ -23,18 +23,20 @@
 #include "verdict.h"
 #include "verdict_defines.hpp"
 
-#include <algorithm>
-#include <vector>
+#include <math.h>
 
 namespace VERDICT_NAMESPACE
 {
-static const double sqrt2 = std::sqrt(2.0);
-static const double radius_ratio_normal_coeff = 1. / (2. * sqrt2);
+
+VERDICT_HOST_DEVICE static double radius_ratio_normal_coeff()
+{
+  return 1.0 / (2.0 * sqrt(2.0));
+}
 
 /*!
   weights based on the average size of a quad
  */
-static int quad_get_weight(
+VERDICT_HOST_DEVICE static int quad_get_weight(
   double& m11, double& m21, double& m12, double& m22, double average_quad_size)
 {
 
@@ -43,7 +45,7 @@ static int quad_get_weight(
   m12 = 0;
   m22 = 1;
 
-  double scale = std::sqrt(average_quad_size / (m11 * m22 - m21 * m12));
+  double scale = sqrt(average_quad_size / (m11 * m22 - m21 * m12));
 
   m11 *= scale;
   m21 *= scale;
@@ -54,7 +56,7 @@ static int quad_get_weight(
 }
 
 //! returns whether the quad is collapsed or not
-static VerdictBoolean is_collapsed_quad(const double coordinates[][3])
+VERDICT_HOST_DEVICE static VerdictBoolean is_collapsed_quad(const double coordinates[][3])
 {
   if (coordinates[3][0] == coordinates[2][0] && coordinates[3][1] == coordinates[2][1] &&
     coordinates[3][2] == coordinates[2][2])
@@ -67,7 +69,7 @@ static VerdictBoolean is_collapsed_quad(const double coordinates[][3])
   }
 }
 
-static void make_quad_edges(VerdictVector edges[4], const double coordinates[][3])
+VERDICT_HOST_DEVICE static void make_quad_edges(VerdictVector edges[4], const double coordinates[][3])
 {
 
   edges[0].set(coordinates[1][0] - coordinates[0][0], coordinates[1][1] - coordinates[0][1],
@@ -80,7 +82,7 @@ static void make_quad_edges(VerdictVector edges[4], const double coordinates[][3
     coordinates[0][2] - coordinates[3][2]);
 }
 
-static void signed_corner_areas(double areas[4], const double coordinates[][3])
+VERDICT_HOST_DEVICE static void signed_corner_areas(double areas[4], const double coordinates[][3])
 {
   VerdictVector edges[4];
   make_quad_edges(edges, coordinates);
@@ -117,7 +119,7 @@ static void signed_corner_areas(double areas[4], const double coordinates[][3])
   and the quad normal lines up with the y axis.
 
  */
-static void localize_quad_coordinates(VerdictVector nodes[4])
+VERDICT_HOST_DEVICE static void localize_quad_coordinates(VerdictVector nodes[4])
 {
   int i;
   VerdictVector global[4] = { nodes[0], nodes[1], nodes[2], nodes[3] };
@@ -170,7 +172,7 @@ static void localize_quad_coordinates(VerdictVector nodes[4])
   moves and rotates the quad such that it enables us to 
   use components of ef's
  */
-static void localize_quad_for_ef( VerdictVector node_pos[4] )
+VERDICT_HOST_DEVICE static void localize_quad_for_ef( VerdictVector node_pos[4] )
 {
 
   VerdictVector centroid(node_pos[0]);
@@ -205,7 +207,7 @@ static void localize_quad_for_ef( VerdictVector node_pos[4] )
 /*!
   returns the normal vector of a quad
  */
-static VerdictVector quad_normal(const double coordinates[][3])
+VERDICT_HOST_DEVICE static VerdictVector quad_normal(const double coordinates[][3])
 {
   // get normal at node 0
   VerdictVector edge0, edge1;
@@ -265,7 +267,7 @@ static VerdictVector quad_normal(const double coordinates[][3])
   }
 }
 
-void quad_minimum_maximum_angle(double min_max_angles[2], const double coordinates[][3])
+VERDICT_HOST_DEVICE void quad_minimum_maximum_angle(double min_max_angles[2], const double coordinates[][3])
 {
   // if this is a collapsed quad, just pass it on to
   // the tri_largest_angle routine
@@ -306,30 +308,30 @@ void quad_minimum_maximum_angle(double min_max_angles[2], const double coordinat
     return;
   }
 
-  angle = std::acos(-(edges[0] % edges[1]) / (length[0] * length[1]));
-  min_angle = std::min(angle, min_angle);
-  max_angle = std::max(angle, max_angle);
+  angle = acos(-(edges[0] % edges[1]) / (length[0] * length[1]));
+  min_angle = fmin(angle, min_angle);
+  max_angle = fmax(angle, max_angle);
 
-  angle = std::acos(-(edges[1] % edges[2]) / (length[1] * length[2]));
-  min_angle = std::min(angle, min_angle);
-  max_angle = std::max(angle, max_angle);
+  angle = acos(-(edges[1] % edges[2]) / (length[1] * length[2]));
+  min_angle = fmin(angle, min_angle);
+  max_angle = fmax(angle, max_angle);
 
-  angle = std::acos(-(edges[2] % edges[3]) / (length[2] * length[3]));
-  min_angle = std::min(angle, min_angle);
-  max_angle = std::max(angle, max_angle);
+  angle = acos(-(edges[2] % edges[3]) / (length[2] * length[3]));
+  min_angle = fmin(angle, min_angle);
+  max_angle = fmax(angle, max_angle);
 
-  angle = std::acos(-(edges[3] % edges[0]) / (length[3] * length[0]));
-  min_angle = std::min(angle, min_angle);
-  max_angle = std::max(angle, max_angle);
+  angle = acos(-(edges[3] % edges[0]) / (length[3] * length[0]));
+  min_angle = fmin(angle, min_angle);
+  max_angle = fmax(angle, max_angle);
 
   max_angle = max_angle * 180.0 / VERDICT_PI;
   min_angle = min_angle * 180.0 / VERDICT_PI;
 
   if (min_angle > 0)
   {
-    min_max_angles[0] = (double)std::min(min_angle, VERDICT_DBL_MAX);
+    min_max_angles[0] = fmin(min_angle, VERDICT_DBL_MAX);
   }
-  min_max_angles[0] = (double)std::max(min_angle, -VERDICT_DBL_MAX);
+  min_max_angles[0] = fmax(min_angle, -VERDICT_DBL_MAX);
 
   // if any signed areas are < 0, then you are getting the wrong angle
   double areas[4];
@@ -342,9 +344,9 @@ void quad_minimum_maximum_angle(double min_max_angles[2], const double coordinat
 
   if (max_angle > 0)
   {
-    min_max_angles[1] = (double)std::min(max_angle, VERDICT_DBL_MAX);
+    min_max_angles[1] = fmin(max_angle, VERDICT_DBL_MAX);
   }
-  min_max_angles[1] = (double)std::max(max_angle, -VERDICT_DBL_MAX);
+  min_max_angles[1] = fmax(max_angle, -VERDICT_DBL_MAX);
 }
 
 /*!
@@ -354,7 +356,7 @@ void quad_minimum_maximum_angle(double min_max_angles[2], const double coordinat
      Hmax / Hmin where Hmax and Hmin are respectively the maximum and the
      minimum edge lengths
  */
-double quad_edge_ratio(int /*num_nodes*/, const double coordinates[][3])
+VERDICT_HOST_DEVICE double quad_edge_ratio(int /*num_nodes*/, const double coordinates[][3])
 {
   VerdictVector edges[4];
   make_quad_edges(edges, coordinates);
@@ -394,13 +396,13 @@ double quad_edge_ratio(int /*num_nodes*/, const double coordinates[][3])
   }
   else
   {
-    double edge_ratio = std::sqrt(M2 / m2);
+    double edge_ratio = sqrt(M2 / m2);
 
     if (edge_ratio > 0)
     {
-      return (double)std::min(edge_ratio, VERDICT_DBL_MAX);
+      return fmin(edge_ratio, VERDICT_DBL_MAX);
     }
-    return (double)std::max(edge_ratio, -VERDICT_DBL_MAX);
+    return fmax(edge_ratio, -VERDICT_DBL_MAX);
   }
 }
 
@@ -409,7 +411,7 @@ double quad_edge_ratio(int /*num_nodes*/, const double coordinates[][3])
 
   maximum edge length ratio at quad center
  */
-double quad_max_edge_ratio(int /*num_nodes*/, const double coordinates[][3])
+VERDICT_HOST_DEVICE double quad_max_edge_ratio(int /*num_nodes*/, const double coordinates[][3])
 {
   VerdictVector quad_nodes[4];
   quad_nodes[0].set(coordinates[0][0], coordinates[0][1], coordinates[0][2]);
@@ -429,13 +431,13 @@ double quad_max_edge_ratio(int /*num_nodes*/, const double coordinates[][3])
     return (double)VERDICT_DBL_MAX;
   }
 
-  double max_edge_ratio = std::max(len1 / len2, len2 / len1);
+  double max_edge_ratio = fmax(len1 / len2, len2 / len1);
 
   if (max_edge_ratio > 0)
   {
-    return (double)std::min(max_edge_ratio, VERDICT_DBL_MAX);
+    return fmin(max_edge_ratio, VERDICT_DBL_MAX);
   }
-  return (double)std::max(max_edge_ratio, -VERDICT_DBL_MAX);
+  return fmax(max_edge_ratio, -VERDICT_DBL_MAX);
 }
 
 /*!
@@ -445,7 +447,7 @@ double quad_max_edge_ratio(int /*num_nodes*/, const double coordinates[][3])
      this is a generalization of the triangle aspect ratio
      using Heron's formula.
  */
-double quad_aspect_ratio(int /*num_nodes*/, const double coordinates[][3])
+VERDICT_HOST_DEVICE double quad_aspect_ratio(int /*num_nodes*/, const double coordinates[][3])
 {
 
   VerdictVector edges[4];
@@ -467,9 +469,9 @@ double quad_aspect_ratio(int /*num_nodes*/, const double coordinates[][3])
 
   if (aspect_ratio > 0)
   {
-    return (double)std::min(aspect_ratio, VERDICT_DBL_MAX);
+    return fmin(aspect_ratio, VERDICT_DBL_MAX);
   }
-  return (double)std::max(aspect_ratio, -VERDICT_DBL_MAX);
+  return fmax(aspect_ratio, -VERDICT_DBL_MAX);
 }
 
 /*!
@@ -480,7 +482,7 @@ double quad_aspect_ratio(int /*num_nodes*/, const double coordinates[][3])
      not exist in general with quads -- although a different name should probably
      be used in the future.
  */
-double quad_radius_ratio(int /*num_nodes*/, const double coordinates[][3])
+VERDICT_HOST_DEVICE double quad_radius_ratio(int /*num_nodes*/, const double coordinates[][3])
 {
   VerdictVector edges[4];
   make_quad_edges(edges, coordinates);
@@ -524,13 +526,13 @@ double quad_radius_ratio(int /*num_nodes*/, const double coordinates[][3])
     return (double)VERDICT_DBL_MAX;
   }
 
-  double radius_ratio = radius_ratio_normal_coeff * std::sqrt((a2 + b2 + c2 + d2) * h2) / t0;
+  double radius_ratio = radius_ratio_normal_coeff() * sqrt((a2 + b2 + c2 + d2) * h2) / t0;
 
   if (radius_ratio > 0)
   {
-    return (double)std::min(radius_ratio, VERDICT_DBL_MAX);
+    return fmin(radius_ratio, VERDICT_DBL_MAX);
   }
-  return (double)std::max(radius_ratio, -VERDICT_DBL_MAX);
+  return fmax(radius_ratio, -VERDICT_DBL_MAX);
 }
 
 /*!
@@ -540,7 +542,7 @@ double quad_radius_ratio(int /*num_nodes*/, const double coordinates[][3])
      this function is calculated by averaging the 4 Frobenius aspects at
      each corner of the quad, when the reference triangle is right isosceles.
  */
-double quad_med_aspect_frobenius(int /*num_nodes*/, const double coordinates[][3])
+VERDICT_HOST_DEVICE double quad_med_aspect_frobenius(int /*num_nodes*/, const double coordinates[][3])
 {
 
   VerdictVector edges[4];
@@ -576,9 +578,9 @@ double quad_med_aspect_frobenius(int /*num_nodes*/, const double coordinates[][3
 
   if (med_aspect_frobenius > 0)
   {
-    return (double)std::min(med_aspect_frobenius, VERDICT_DBL_MAX);
+    return fmin(med_aspect_frobenius, VERDICT_DBL_MAX);
   }
-  return (double)std::max(med_aspect_frobenius, -VERDICT_DBL_MAX);
+  return fmax(med_aspect_frobenius, -VERDICT_DBL_MAX);
 }
 
 /*!
@@ -588,7 +590,7 @@ double quad_med_aspect_frobenius(int /*num_nodes*/, const double coordinates[][3
      this function is calculated by taking the maximum of the 4 Frobenius aspects at
      each corner of the quad, when the reference triangle is right isosceles.
  */
-double quad_max_aspect_frobenius(int /*num_nodes*/, const double coordinates[][3])
+VERDICT_HOST_DEVICE double quad_max_aspect_frobenius(int /*num_nodes*/, const double coordinates[][3])
 {
 
   VerdictVector edges[4];
@@ -630,9 +632,9 @@ double quad_max_aspect_frobenius(int /*num_nodes*/, const double coordinates[][3
 
   if (max_aspect_frobenius > 0)
   {
-    return (double)std::min(max_aspect_frobenius, VERDICT_DBL_MAX);
+    return fmin(max_aspect_frobenius, VERDICT_DBL_MAX);
   }
-  return (double)std::max(max_aspect_frobenius, -VERDICT_DBL_MAX);
+  return fmax(max_aspect_frobenius, -VERDICT_DBL_MAX);
 }
 
 /*!
@@ -640,7 +642,7 @@ double quad_max_aspect_frobenius(int /*num_nodes*/, const double coordinates[][3
 
   maximum ||cos A|| where A is the angle between edges at quad center
  */
-double quad_skew(int /*num_nodes*/, const double coordinates[][3])
+VERDICT_HOST_DEVICE double quad_skew(int /*num_nodes*/, const double coordinates[][3])
 {
   VerdictVector node_pos[4];
   for (int i = 0; i < 4; i++)
@@ -661,8 +663,8 @@ double quad_skew(int /*num_nodes*/, const double coordinates[][3])
     return 0.0;
   }
 
-  double skew = std::abs(principle_axes[0] % principle_axes[1]);
-  return (double)std::min(skew, VERDICT_DBL_MAX);
+  double skew = fabs(principle_axes[0] % principle_axes[1]);
+  return fmin(skew, VERDICT_DBL_MAX);
 }
 
 /*!
@@ -670,7 +672,7 @@ double quad_skew(int /*num_nodes*/, const double coordinates[][3])
 
   maximum ratio of lengths derived from opposite edges
  */
-double quad_taper(int /*num_nodes*/, const double coordinates[][3])
+VERDICT_HOST_DEVICE double quad_taper(int /*num_nodes*/, const double coordinates[][3])
 {
   VerdictVector node_pos[4];
   for (int i = 0; i < 4; i++)
@@ -689,7 +691,7 @@ double quad_taper(int /*num_nodes*/, const double coordinates[][3])
   lengths[1] = principle_axes[1].length();
 
   // get min length
-  lengths[0] = std::min(lengths[0], lengths[1]);
+  lengths[0] = fmin(lengths[0], lengths[1]);
 
   if (lengths[0] < VERDICT_DBL_MIN)
   {
@@ -697,7 +699,7 @@ double quad_taper(int /*num_nodes*/, const double coordinates[][3])
   }
 
   double taper = cross_derivative.length() / lengths[0];
-  return (double)std::min(taper, VERDICT_DBL_MAX);
+  return fmin(taper, VERDICT_DBL_MAX);
 }
 
 /*!
@@ -705,7 +707,7 @@ double quad_taper(int /*num_nodes*/, const double coordinates[][3])
 
   deviation of element from planarity
  */
-double quad_warpage(int /*num_nodes*/, const double coordinates[][3])
+VERDICT_HOST_DEVICE double quad_warpage(int /*num_nodes*/, const double coordinates[][3])
 {
   VerdictVector edges[4];
   make_quad_edges(edges, coordinates);
@@ -724,14 +726,14 @@ double quad_warpage(int /*num_nodes*/, const double coordinates[][3])
     return (double)VERDICT_DBL_MIN;
   }
 
-  double warpage = std::pow(
-    std::min(corner_normals[0] % corner_normals[2], corner_normals[1] % corner_normals[3]), 3);
+  double warpage = fmin(corner_normals[0] % corner_normals[2], corner_normals[1] % corner_normals[3]);
+  warpage = warpage * warpage * warpage;
 
   if (warpage > 0)
   {
-    return (double)std::min(warpage, VERDICT_DBL_MAX);
+    return fmin(warpage, VERDICT_DBL_MAX);
   }
-  return (double)std::max(warpage, -VERDICT_DBL_MAX);
+  return fmax(warpage, -VERDICT_DBL_MAX);
 }
 
 /*!
@@ -739,7 +741,7 @@ double quad_warpage(int /*num_nodes*/, const double coordinates[][3])
 
   jacobian at quad center
  */
-double quad_area(int num_nodes, const double coordinates[][3])
+VERDICT_HOST_DEVICE double quad_area(int num_nodes, const double coordinates[][3])
 {
   if (4 == num_nodes)
   {
@@ -750,9 +752,9 @@ double quad_area(int num_nodes, const double coordinates[][3])
 
     if (area > 0)
     {
-      return (double)std::min(area, VERDICT_DBL_MAX);
+      return fmin(area, VERDICT_DBL_MAX);
     }
-    return (double)std::max(area, -VERDICT_DBL_MAX);
+    return fmax(area, -VERDICT_DBL_MAX);
   }
   else 
   {
@@ -761,14 +763,14 @@ double quad_area(int num_nodes, const double coordinates[][3])
     
     if (5 == num_nodes)
     {
-      std::vector< std::vector<int> > tri_conn = { {0,1}, {1,2}, {2,3}, {3,0} };
+      const int tri_conn[4][2] = { {0,1}, {1,2}, {2,3}, {3,0} };
 
       //center node 4
       tmp_coords[2][0] = coordinates[4][0];
       tmp_coords[2][1] = coordinates[4][1];
       tmp_coords[2][2] = coordinates[4][2];
 
-      for (std::vector<int> v : tri_conn)
+      for (const int* v : tri_conn)
       {
         tmp_coords[0][0] = coordinates[v[0]][0];
         tmp_coords[0][1] = coordinates[v[0]][1];
@@ -781,10 +783,9 @@ double quad_area(int num_nodes, const double coordinates[][3])
     }
     else if (8 == num_nodes)
     {
-      std::vector< std::vector<int> > tri_conn = 
-        { {0,4,7}, {4,1,5}, {5,2,6}, {6,3,7} };
+      const int tri_conn[4][3] = { {0,4,7}, {4,1,5}, {5,2,6}, {6,3,7} };
 
-      for (std::vector<int> v : tri_conn)
+      for (const int* v : tri_conn)
       {
         tmp_coords[0][0] = coordinates[v[0]][0];
         tmp_coords[0][1] = coordinates[v[0]][1];
@@ -815,7 +816,7 @@ double quad_area(int num_nodes, const double coordinates[][3])
     }
     else if (9 == num_nodes)
     {
-      std::vector< std::vector<int> > tri_conn =
+      const int tri_conn[8][2] =
       { {0,4}, {4,1}, {1,5}, {5,2}, {2,6}, {6,3}, {3,7}, {7,0} };
 
       //quad center node
@@ -823,7 +824,7 @@ double quad_area(int num_nodes, const double coordinates[][3])
       tmp_coords[2][1] = coordinates[8][1];
       tmp_coords[2][2] = coordinates[8][2];
 
-      for (std::vector<int> v : tri_conn)
+      for (const int* v : tri_conn)
       {
         tmp_coords[0][0] = coordinates[v[0]][0];
         tmp_coords[0][1] = coordinates[v[0]][1];
@@ -843,7 +844,7 @@ double quad_area(int num_nodes, const double coordinates[][3])
 
   sqrt(2) * minimum edge length / maximum diagonal length
  */
-double quad_stretch(int /*num_nodes*/, const double coordinates[][3])
+VERDICT_HOST_DEVICE double quad_stretch(int /*num_nodes*/, const double coordinates[][3])
 {
   VerdictVector edges[4], temp;
   make_quad_edges(edges, coordinates);
@@ -863,7 +864,7 @@ double quad_stretch(int /*num_nodes*/, const double coordinates[][3])
   double diag13 = temp.length_squared();
 
   // 'diag02' is now the max diagonal of the quad
-  diag02 = std::max(diag02, diag13);
+  diag02 = fmax(diag02, diag13);
 
   if (diag02 < VERDICT_DBL_MIN)
   {
@@ -871,12 +872,12 @@ double quad_stretch(int /*num_nodes*/, const double coordinates[][3])
   }
   else
   {
-    double stretch = (double)(sqrt2 *
-      std::sqrt(std::min(std::min(lengths_squared[0], lengths_squared[1]),
-                  std::min(lengths_squared[2], lengths_squared[3])) /
+    double stretch = (double)(sqrt(2.0) *
+      sqrt(fmin(fmin(lengths_squared[0], lengths_squared[1]),
+                  fmin(lengths_squared[2], lengths_squared[3])) /
         diag02));
 
-    return (double)std::min(stretch, VERDICT_DBL_MAX);
+    return fmin(stretch, VERDICT_DBL_MAX);
   }
 }
 
@@ -885,7 +886,7 @@ double quad_stretch(int /*num_nodes*/, const double coordinates[][3])
 
   largest included quad area (degrees)
  */
-double quad_maximum_angle(int /*num_nodes*/, const double coordinates[][3])
+VERDICT_HOST_DEVICE double quad_maximum_angle(int /*num_nodes*/, const double coordinates[][3])
 {
   // if this is a collapsed quad, just pass it on to
   // the tri_largest_angle routine
@@ -921,17 +922,17 @@ double quad_maximum_angle(int /*num_nodes*/, const double coordinates[][3])
     return 0.0;
   }
 
-  angle = std::acos(-(edges[0] % edges[1]) / (length[0] * length[1]));
-  max_angle = std::max(angle, max_angle);
+  angle = acos(-(edges[0] % edges[1]) / (length[0] * length[1]));
+  max_angle = fmax(angle, max_angle);
 
-  angle = std::acos(-(edges[1] % edges[2]) / (length[1] * length[2]));
-  max_angle = std::max(angle, max_angle);
+  angle = acos(-(edges[1] % edges[2]) / (length[1] * length[2]));
+  max_angle = fmax(angle, max_angle);
 
-  angle = std::acos(-(edges[2] % edges[3]) / (length[2] * length[3]));
-  max_angle = std::max(angle, max_angle);
+  angle = acos(-(edges[2] % edges[3]) / (length[2] * length[3]));
+  max_angle = fmax(angle, max_angle);
 
-  angle = std::acos(-(edges[3] % edges[0]) / (length[3] * length[0]));
-  max_angle = std::max(angle, max_angle);
+  angle = acos(-(edges[3] % edges[0]) / (length[3] * length[0]));
+  max_angle = fmax(angle, max_angle);
 
   max_angle = max_angle * 180.0 / VERDICT_PI;
 
@@ -946,9 +947,9 @@ double quad_maximum_angle(int /*num_nodes*/, const double coordinates[][3])
 
   if (max_angle > 0)
   {
-    return (double)std::min(max_angle, VERDICT_DBL_MAX);
+    return fmin(max_angle, VERDICT_DBL_MAX);
   }
-  return (double)std::max(max_angle, -VERDICT_DBL_MAX);
+  return fmax(max_angle, -VERDICT_DBL_MAX);
 }
 
 /*!
@@ -956,7 +957,7 @@ double quad_maximum_angle(int /*num_nodes*/, const double coordinates[][3])
 
   smallest included quad angle (degrees)
  */
-double quad_minimum_angle(int /*num_nodes*/, const double coordinates[][3])
+VERDICT_HOST_DEVICE double quad_minimum_angle(int /*num_nodes*/, const double coordinates[][3])
 {
   // if this quad is a collapsed quad, then just
   // send it to the tri_smallest_angle routine
@@ -992,28 +993,28 @@ double quad_minimum_angle(int /*num_nodes*/, const double coordinates[][3])
     return 360.0;
   }
 
-  angle = std::acos(-(edges[0] % edges[1]) / (length[0] * length[1]));
-  min_angle = std::min(angle, min_angle);
+  angle = acos(-(edges[0] % edges[1]) / (length[0] * length[1]));
+  min_angle = fmin(angle, min_angle);
 
-  angle = std::acos(-(edges[1] % edges[2]) / (length[1] * length[2]));
-  min_angle = std::min(angle, min_angle);
+  angle = acos(-(edges[1] % edges[2]) / (length[1] * length[2]));
+  min_angle = fmin(angle, min_angle);
 
-  angle = std::acos(-(edges[2] % edges[3]) / (length[2] * length[3]));
-  min_angle = std::min(angle, min_angle);
+  angle = acos(-(edges[2] % edges[3]) / (length[2] * length[3]));
+  min_angle = fmin(angle, min_angle);
 
-  angle = std::acos(-(edges[3] % edges[0]) / (length[3] * length[0]));
-  min_angle = std::min(angle, min_angle);
+  angle = acos(-(edges[3] % edges[0]) / (length[3] * length[0]));
+  min_angle = fmin(angle, min_angle);
 
   min_angle = min_angle * 180.0 / VERDICT_PI;
 
   if (min_angle > 0)
   {
-    return (double)std::min(min_angle, VERDICT_DBL_MAX);
+    return fmin(min_angle, VERDICT_DBL_MAX);
   }
-  return (double)std::max(min_angle, -VERDICT_DBL_MAX);
+  return fmax(min_angle, -VERDICT_DBL_MAX);
 }
 
-double quad_equiangle_skew(int /*num_nodes*/, const double coordinates[][3])
+VERDICT_HOST_DEVICE double quad_equiangle_skew(int /*num_nodes*/, const double coordinates[][3])
 {
   double min_max_angle[2];
 
@@ -1034,7 +1035,7 @@ double quad_equiangle_skew(int /*num_nodes*/, const double coordinates[][3])
 
   general distortion measure based on left Cauchy-Green Tensor
  */
-double quad_oddy(int /*num_nodes*/, const double coordinates[][3])
+VERDICT_HOST_DEVICE double quad_oddy(int /*num_nodes*/, const double coordinates[][3])
 {
   double max_oddy = 0.;
 
@@ -1066,14 +1067,14 @@ double quad_oddy(int /*num_nodes*/, const double coordinates[][3])
     {
       cur_oddy = ((g11 - g22) * (g11 - g22) + 4. * g12 * g12) / 2. / g;
     }
-    max_oddy = std::max(max_oddy, cur_oddy);
+    max_oddy = fmax(max_oddy, cur_oddy);
   }
 
   if (max_oddy > 0)
   {
-    return (double)std::min(max_oddy, VERDICT_DBL_MAX);
+    return fmin(max_oddy, VERDICT_DBL_MAX);
   }
-  return (double)std::max(max_oddy, -VERDICT_DBL_MAX);
+  return fmax(max_oddy, -VERDICT_DBL_MAX);
 }
 
 /*!
@@ -1081,7 +1082,7 @@ double quad_oddy(int /*num_nodes*/, const double coordinates[][3])
 
   maximum condition number of the Jacobian matrix at 4 corners
  */
-double quad_condition(int /*num_nodes*/, const double coordinates[][3])
+VERDICT_HOST_DEVICE double quad_condition(int /*num_nodes*/, const double coordinates[][3])
 {
   if (is_collapsed_quad(coordinates) == VERDICT_TRUE)
   {
@@ -1115,7 +1116,7 @@ double quad_condition(int /*num_nodes*/, const double coordinates[][3])
     {
       condition = (xxi % xxi + xet % xet) / areas[i];
     }
-    max_condition = std::max(max_condition, condition);
+    max_condition = fmax(max_condition, condition);
   }
 
   if (max_condition >= VERDICT_DBL_MAX)
@@ -1134,7 +1135,7 @@ double quad_condition(int /*num_nodes*/, const double coordinates[][3])
 
   minimum pointwise volume of local map at 4 corners and center of quad
 */
-double quad_jacobian(int /*num_nodes*/, const double coordinates[][3])
+VERDICT_HOST_DEVICE double quad_jacobian(int /*num_nodes*/, const double coordinates[][3])
 {
 
   if (is_collapsed_quad(coordinates) == VERDICT_TRUE)
@@ -1145,12 +1146,12 @@ double quad_jacobian(int /*num_nodes*/, const double coordinates[][3])
   double areas[4];
   signed_corner_areas(areas, coordinates);
 
-  double jacobian = std::min(std::min(areas[0], areas[1]), std::min(areas[2], areas[3]));
+  double jacobian = fmin(fmin(areas[0], areas[1]), fmin(areas[2], areas[3]));
   if (jacobian > 0)
   {
-    return (double)std::min(jacobian, VERDICT_DBL_MAX);
+    return fmin(jacobian, VERDICT_DBL_MAX);
   }
-  return (double)std::max(jacobian, -VERDICT_DBL_MAX);
+  return fmax(jacobian, -VERDICT_DBL_MAX);
 }
 
 /*!
@@ -1158,7 +1159,7 @@ double quad_jacobian(int /*num_nodes*/, const double coordinates[][3])
 
   Minimum Jacobian divided by the lengths of the 2 edge vector
  */
-double quad_scaled_jacobian(int /*num_nodes*/, const double coordinates[][3])
+VERDICT_HOST_DEVICE double quad_scaled_jacobian(int /*num_nodes*/, const double coordinates[][3])
 {
   if (is_collapsed_quad(coordinates) == VERDICT_TRUE)
   {
@@ -1184,22 +1185,22 @@ double quad_scaled_jacobian(int /*num_nodes*/, const double coordinates[][3])
   }
 
   scaled_jac = corner_areas[0] / (length[0] * length[3]);
-  min_scaled_jac = std::min(scaled_jac, min_scaled_jac);
+  min_scaled_jac = fmin(scaled_jac, min_scaled_jac);
 
   scaled_jac = corner_areas[1] / (length[1] * length[0]);
-  min_scaled_jac = std::min(scaled_jac, min_scaled_jac);
+  min_scaled_jac = fmin(scaled_jac, min_scaled_jac);
 
   scaled_jac = corner_areas[2] / (length[2] * length[1]);
-  min_scaled_jac = std::min(scaled_jac, min_scaled_jac);
+  min_scaled_jac = fmin(scaled_jac, min_scaled_jac);
 
   scaled_jac = corner_areas[3] / (length[3] * length[2]);
-  min_scaled_jac = std::min(scaled_jac, min_scaled_jac);
+  min_scaled_jac = fmin(scaled_jac, min_scaled_jac);
 
   if (min_scaled_jac > 0)
   {
-    return (double)std::min(min_scaled_jac, VERDICT_DBL_MAX);
+    return fmin(min_scaled_jac, VERDICT_DBL_MAX);
   }
-  return (double)std::max(min_scaled_jac, -VERDICT_DBL_MAX);
+  return fmax(min_scaled_jac, -VERDICT_DBL_MAX);
 }
 
 /*!
@@ -1207,7 +1208,7 @@ double quad_scaled_jacobian(int /*num_nodes*/, const double coordinates[][3])
 
   2/Condition number of Jacobian Skew matrix
  */
-double quad_shear(int /*num_nodes*/, const double coordinates[][3])
+VERDICT_HOST_DEVICE double quad_shear(int /*num_nodes*/, const double coordinates[][3])
 {
   double scaled_jacobian = quad_scaled_jacobian(4, coordinates);
 
@@ -1217,7 +1218,7 @@ double quad_shear(int /*num_nodes*/, const double coordinates[][3])
   }
   else
   {
-    return (double)std::min(scaled_jacobian, VERDICT_DBL_MAX);
+    return fmin(scaled_jacobian, VERDICT_DBL_MAX);
   }
 }
 
@@ -1226,7 +1227,7 @@ double quad_shear(int /*num_nodes*/, const double coordinates[][3])
 
    2/Condition number of weighted Jacobian matrix
  */
-double quad_shape(int /*num_nodes*/, const double coordinates[][3])
+VERDICT_HOST_DEVICE double quad_shape(int /*num_nodes*/, const double coordinates[][3])
 {
 
   double corner_areas[4], min_shape = VERDICT_DBL_MAX, shape;
@@ -1248,16 +1249,16 @@ double quad_shape(int /*num_nodes*/, const double coordinates[][3])
   }
 
   shape = corner_areas[0] / (length_squared[0] + length_squared[3]);
-  min_shape = std::min(shape, min_shape);
+  min_shape = fmin(shape, min_shape);
 
   shape = corner_areas[1] / (length_squared[1] + length_squared[0]);
-  min_shape = std::min(shape, min_shape);
+  min_shape = fmin(shape, min_shape);
 
   shape = corner_areas[2] / (length_squared[2] + length_squared[1]);
-  min_shape = std::min(shape, min_shape);
+  min_shape = fmin(shape, min_shape);
 
   shape = corner_areas[3] / (length_squared[3] + length_squared[2]);
-  min_shape = std::min(shape, min_shape);
+  min_shape = fmin(shape, min_shape);
 
   min_shape *= 2;
 
@@ -1268,9 +1269,9 @@ double quad_shape(int /*num_nodes*/, const double coordinates[][3])
 
   if (min_shape > 0)
   {
-    return (double)std::min(min_shape, VERDICT_DBL_MAX);
+    return fmin(min_shape, VERDICT_DBL_MAX);
   }
-  return (double)std::max(min_shape, -VERDICT_DBL_MAX);
+  return fmax(min_shape, -VERDICT_DBL_MAX);
 }
 
 /*!
@@ -1278,7 +1279,7 @@ double quad_shape(int /*num_nodes*/, const double coordinates[][3])
 
   Min( J, 1/J ), where J is determinant of weighted Jacobian matrix
 */
-double quad_relative_size_squared(
+VERDICT_HOST_DEVICE double quad_relative_size_squared(
   int /*num_nodes*/, const double coordinates[][3], double average_quad_area)
 {
   double the_quad_area = quad_area(4, coordinates);
@@ -1294,16 +1295,16 @@ double quad_relative_size_squared(
 
     if (w11 > VERDICT_DBL_MIN)
     {
-      rel_size = std::min(w11, 1 / w11);
+      rel_size = fmin(w11, 1 / w11);
       rel_size *= rel_size;
     }
   }
 
   if (rel_size > 0)
   {
-    return (double)std::min(rel_size, VERDICT_DBL_MAX);
+    return fmin(rel_size, VERDICT_DBL_MAX);
   }
-  return (double)std::max(rel_size, -VERDICT_DBL_MAX);
+  return fmax(rel_size, -VERDICT_DBL_MAX);
 }
 
 /*!
@@ -1311,7 +1312,7 @@ double quad_relative_size_squared(
 
   Product of Shape and Relative Size
  */
-double quad_shape_and_size(int num_nodes, const double coordinates[][3], double average_quad_area)
+VERDICT_HOST_DEVICE double quad_shape_and_size(int num_nodes, const double coordinates[][3], double average_quad_area)
 {
   double shape, size;
   size = quad_relative_size_squared(num_nodes, coordinates, average_quad_area);
@@ -1321,9 +1322,9 @@ double quad_shape_and_size(int num_nodes, const double coordinates[][3], double 
 
   if (shape_and_size > 0)
   {
-    return (double)std::min(shape_and_size, VERDICT_DBL_MAX);
+    return fmin(shape_and_size, VERDICT_DBL_MAX);
   }
-  return (double)std::max(shape_and_size, -VERDICT_DBL_MAX);
+  return fmax(shape_and_size, -VERDICT_DBL_MAX);
 }
 
 /*!
@@ -1331,7 +1332,7 @@ double quad_shape_and_size(int num_nodes, const double coordinates[][3], double 
 
   product of shear and relative size
  */
-double quad_shear_and_size(int num_nodes, const double coordinates[][3], double average_quad_area)
+VERDICT_HOST_DEVICE double quad_shear_and_size(int num_nodes, const double coordinates[][3], double average_quad_area)
 {
   double shear, size;
   shear = quad_shear(num_nodes, coordinates);
@@ -1341,15 +1342,15 @@ double quad_shear_and_size(int num_nodes, const double coordinates[][3], double 
 
   if (shear_and_size > 0)
   {
-    return (double)std::min(shear_and_size, VERDICT_DBL_MAX);
+    return fmin(shear_and_size, VERDICT_DBL_MAX);
   }
-  return (double)std::max(shear_and_size, -VERDICT_DBL_MAX);
+  return fmax(shear_and_size, -VERDICT_DBL_MAX);
 }
 
 /*!
   the distortion of a quad
 */
-double quad_distortion(int num_nodes, const double coordinates[][3])
+VERDICT_HOST_DEVICE double quad_distortion(int num_nodes, const double coordinates[][3])
 {
   // To calculate distortion for linear and 2nd order quads
   // distortion = {min(|J|)/actual area}*{parent area}
@@ -1396,7 +1397,7 @@ double quad_distortion(int num_nodes, const double coordinates[][3])
 
       sign_jacobian = (face_normal % (first * second)) > 0 ? 1. : -1.;
       cur_jacobian = sign_jacobian * (first * second).length();
-      distortion = std::min(distortion, cur_jacobian);
+      distortion = fmin(distortion, cur_jacobian);
     }
     element_area = (first * second).length() / 2.0;
     distortion /= element_area;
@@ -1462,7 +1463,7 @@ double quad_distortion(int num_nodes, const double coordinates[][3])
     for (ja = 0; ja < num_nodes; ja++)
     {
       dot_product = normal_at_nodes[0] % normal_at_nodes[ja];
-      if (std::abs(dot_product) < 0.99)
+      if (fabs(dot_product) < 0.99)
       {
         flat_element = false;
         break;
@@ -1472,7 +1473,7 @@ double quad_distortion(int num_nodes, const double coordinates[][3])
     // take into consideration the thickness of the element
     double thickness;
     // get_quad_thickness(face, element_area, thickness );
-    thickness = 0.001 * std::sqrt(element_area);
+    thickness = 0.001 * sqrt(element_area);
 
     // set thickness gauss point location
     double zl = 0.5773502691896;

--- a/V_WedgeMetric.cpp
+++ b/V_WedgeMetric.cpp
@@ -21,19 +21,18 @@
 #include "VerdictVector.hpp"
 #include "verdict.h"
 
-#include <algorithm>
-#include <cmath> // for std::isnan
+#include <math.h>
 
 namespace VERDICT_NAMESPACE
 {
-extern double tri_equiangle_skew(int num_nodes, const double coordinates[][3]);
-extern double quad_equiangle_skew(int num_nodes, const double coordinates[][3]);
+VERDICT_HOST_DEVICE extern double tri_equiangle_skew(int num_nodes, const double coordinates[][3]);
+VERDICT_HOST_DEVICE extern double quad_equiangle_skew(int num_nodes, const double coordinates[][3]);
 
-static const double one_third = 1.0 / 3.0;
-static const double two_thirds = 2.0 / 3.0;
+static constexpr double one_third = 1.0 / 3.0;
+static constexpr double two_thirds = 2.0 / 3.0;
 
 // local methods
-void make_wedge_faces(const double coordinates[][3], double tri1[][3], double tri2[][3],
+VERDICT_HOST_DEVICE void make_wedge_faces(const double coordinates[][3], double tri1[][3], double tri2[][3],
   double quad1[][3], double quad2[][3], double quad3[][3]);
 
 /*
@@ -52,13 +51,36 @@ void make_wedge_faces(const double coordinates[][3], double tri1[][3], double tr
 
  */
 
-static const double WEDGE21_node_local_coord[21][3] = { { 0, 0, -1 }, { 1.0, 0, -1 },
-  { 0, 1.0, -1 }, { 0, 0, 1.0 }, { 1.0, 0, 1.0 }, { 0, 1.0, 1.0 }, { 0.5, 0, -1 }, { 0.5, 0.5, -1 },
-  { 0, 0.5, -1 }, { 0.0, 0.0, 0 }, { 1.0, 0, 0 }, { 0, 1.0, 0 }, { 0.5, 0, 1.0 }, { 0.5, 0.5, 1.0 },
-  { 0, 0.5, 1.0 }, { one_third, one_third, 0 }, { one_third, one_third, -1 },
-  { one_third, one_third, 1.0 }, { 0.5, 0.5, 0 }, { 0, 0.5, 0 }, { 0.5, 0, 0 } };
+VERDICT_HOST_DEVICE static const double* WEDGE21_node_local_coord(int i)
+{
+  static const double s_WEDGE21_node_local_coord[21][3] = {
+    { 0.0, 0, -1 },
+    { 1.0, 0, -1 },
+    { 0, 1.0, -1 },
+    { 0, 0, 1.0 },
+    { 1.0, 0, 1.0 },
+    { 0, 1.0, 1.0 },
+    { 0.5, 0, -1 },
+    { 0.5, 0.5, -1 },
+    { 0, 0.5, -1 },
+    { 0.0, 0.0, 0 },
+    { 1.0, 0, 0 },
+    { 0, 1.0, 0 },
+    { 0.5, 0, 1.0 },
+    { 0.5, 0.5, 1.0 },
+    { 0, 0.5, 1.0 },
+    { one_third, one_third, 0 },
+    { one_third, one_third, -1 },
+    { one_third, one_third, 1.0 },
+    { 0.5, 0.5, 0 },
+    { 0, 0.5, 0 },
+    { 0.5, 0, 0 }
+  };
 
-static void WEDGE21_gradients_of_the_shape_functions_for_RST(
+  return s_WEDGE21_node_local_coord[i];
+}
+
+VERDICT_HOST_DEVICE static void WEDGE21_gradients_of_the_shape_functions_for_RST(
   const double rst[3], double dhdr[21], double dhds[21], double dhdt[21])
 {
   double RSM = 1.0 - rst[0] - rst[1];
@@ -155,7 +177,7 @@ static void WEDGE21_gradients_of_the_shape_functions_for_RST(
   dhdt[15] = -2.0 * 27.0 * rst[2] * RSM * RS;
 }
 
-double wedge_equiangle_skew(int /*num_nodes*/, const double coordinates[][3])
+VERDICT_HOST_DEVICE double wedge_equiangle_skew(int /*num_nodes*/, const double coordinates[][3])
 {
   double tri1[3][3];
   double tri2[3][3];
@@ -187,7 +209,7 @@ double wedge_equiangle_skew(int /*num_nodes*/, const double coordinates[][3])
   and summing the volume of each tet
 
  */
-double wedge_volume(int /*num_nodes*/, const double coordinates[][3])
+VERDICT_HOST_DEVICE double wedge_volume(int /*num_nodes*/, const double coordinates[][3])
 {
   // We need to divide the wedge into 11 tets.
   // This is a better solution than 3 tets or 3 hexes because
@@ -391,7 +413,7 @@ double wedge_volume(int /*num_nodes*/, const double coordinates[][3])
    q for right, unit wedge : 1
    Reference : -
    */
-double wedge_edge_ratio(int /*num_nodes*/, const double coordinates[][3])
+VERDICT_HOST_DEVICE double wedge_edge_ratio(int /*num_nodes*/, const double coordinates[][3])
 {
   VerdictVector a, b, c, d, e, f, g, h, i;
 
@@ -506,9 +528,9 @@ double wedge_edge_ratio(int /*num_nodes*/, const double coordinates[][3])
     min = i2;
   }
 
-  double edge_ratio = std::sqrt(max / min);
+  double edge_ratio = sqrt(max / min);
 
-  if (std::isnan(edge_ratio))
+  if (isnan(edge_ratio))
   {
     return VERDICT_DBL_MAX;
   }
@@ -516,10 +538,10 @@ double wedge_edge_ratio(int /*num_nodes*/, const double coordinates[][3])
   {
     return 1.;
   }
-  return (double)std::min(edge_ratio, VERDICT_DBL_MAX);
+  return fmin(edge_ratio, VERDICT_DBL_MAX);
 }
 
-static void aspects(int num_nodes, const double coordinates[][3], double& aspect1, double& aspect2,
+VERDICT_HOST_DEVICE static void aspects(int num_nodes, const double coordinates[][3], double& aspect1, double& aspect2,
   double& aspect3, double& aspect4, double& aspect5, double& aspect6)
 {
   if (num_nodes < 6)
@@ -673,19 +695,19 @@ static void aspects(int num_nodes, const double coordinates[][3], double& aspect
  Reference : Adapted from section 7.7
  Verdict Function : wedge_max_aspect_frobenius or wedge_condition
  */
-double wedge_max_aspect_frobenius(int num_nodes, const double coordinates[][3])
+VERDICT_HOST_DEVICE double wedge_max_aspect_frobenius(int num_nodes, const double coordinates[][3])
 {
   double aspect1, aspect2, aspect3, aspect4, aspect5, aspect6;
   aspects(num_nodes, coordinates, aspect1, aspect2, aspect3, aspect4, aspect5, aspect6);
 
-  double max_aspect = std::max({ aspect1, aspect2, aspect3, aspect4, aspect5, aspect6 });
+  double max_aspect = fmax(aspect1, fmax(aspect2, fmax(aspect3, fmax(aspect4, fmax(aspect5, aspect6)))));
 
   if (max_aspect >= VERDICT_DBL_MAX)
   {
     return VERDICT_DBL_MAX;
   }
   max_aspect /= 1.16477;
-  return std::max(max_aspect, 1.);
+  return fmax(max_aspect, 1.);
 }
 
 /*
@@ -704,7 +726,7 @@ double wedge_max_aspect_frobenius(int num_nodes, const double coordinates[][3])
    Reference : Adapted from section 7.8
    Verdict Function : wedge_mean_aspect_frobenius
    */
-double wedge_mean_aspect_frobenius(int num_nodes, const double coordinates[][3])
+VERDICT_HOST_DEVICE double wedge_mean_aspect_frobenius(int num_nodes, const double coordinates[][3])
 {
   double aspect1, aspect2, aspect3, aspect4, aspect5, aspect6;
   aspects(num_nodes, coordinates, aspect1, aspect2, aspect3, aspect4, aspect5, aspect6);
@@ -716,7 +738,7 @@ double wedge_mean_aspect_frobenius(int num_nodes, const double coordinates[][3])
   }
 
   mean_aspect /= (6. * 1.16477);
-  return std::max(mean_aspect, 1.);
+  return fmax(mean_aspect, 1.);
 }
 
 /* This is the minimum determinant of the Jacobian matrix evaluated at each
@@ -735,7 +757,7 @@ double wedge_mean_aspect_frobenius(int num_nodes, const double coordinates[][3])
  Reference : Adapted from section 6.10
  Verdict Function : wedge_jacobian
  */
-double wedge_jacobian(int num_nodes, const double coordinates[][3])
+VERDICT_HOST_DEVICE double wedge_jacobian(int num_nodes, const double coordinates[][3])
 {
   if (num_nodes == 21)
   {
@@ -747,7 +769,7 @@ double wedge_jacobian(int num_nodes, const double coordinates[][3])
     for (int i = 0; i < 15; i++)
     {
       WEDGE21_gradients_of_the_shape_functions_for_RST(
-        WEDGE21_node_local_coord[i], dhdr, dhds, dhdt);
+        WEDGE21_node_local_coord(i), dhdr, dhds, dhdt);
       double jacobian[3][3] = { { 0, 0, 0 }, { 0, 0, 0 }, { 0, 0, 0 } };
 
       for (int j = 0; j < 21; j++)
@@ -764,7 +786,7 @@ double wedge_jacobian(int num_nodes, const double coordinates[][3])
       }
       double det =
         (VerdictVector(jacobian[0]) * VerdictVector(jacobian[1])) % VerdictVector(jacobian[2]);
-      min_determinant = std::min(det, min_determinant);
+      min_determinant = fmin(det, min_determinant);
     }
     return min_determinant;
   }
@@ -797,7 +819,7 @@ double wedge_jacobian(int num_nodes, const double coordinates[][3])
       coordinates[0][2] - coordinates[1][2]);
 
     current_jacobian = vec2 % (vec1 * vec3);
-    min_jacobian = std::min(current_jacobian, min_jacobian);
+    min_jacobian = fmin(current_jacobian, min_jacobian);
 
     // node 2
     vec1.set(coordinates[0][0] - coordinates[2][0], coordinates[0][1] - coordinates[2][1],
@@ -810,7 +832,7 @@ double wedge_jacobian(int num_nodes, const double coordinates[][3])
       coordinates[1][2] - coordinates[2][2]);
 
     current_jacobian = vec2 % (vec1 * vec3);
-    min_jacobian = std::min(current_jacobian, min_jacobian);
+    min_jacobian = fmin(current_jacobian, min_jacobian);
 
     // node 3
     vec1.set(coordinates[0][0] - coordinates[3][0], coordinates[0][1] - coordinates[3][1],
@@ -823,7 +845,7 @@ double wedge_jacobian(int num_nodes, const double coordinates[][3])
       coordinates[5][2] - coordinates[3][2]);
 
     current_jacobian = vec2 % (vec1 * vec3);
-    min_jacobian = std::min(current_jacobian, min_jacobian);
+    min_jacobian = fmin(current_jacobian, min_jacobian);
 
     // node 4
     vec1.set(coordinates[1][0] - coordinates[4][0], coordinates[1][1] - coordinates[4][1],
@@ -836,7 +858,7 @@ double wedge_jacobian(int num_nodes, const double coordinates[][3])
       coordinates[3][2] - coordinates[4][2]);
 
     current_jacobian = vec2 % (vec1 * vec3);
-    min_jacobian = std::min(current_jacobian, min_jacobian);
+    min_jacobian = fmin(current_jacobian, min_jacobian);
 
     // node 5
     vec1.set(coordinates[3][0] - coordinates[5][0], coordinates[3][1] - coordinates[5][1],
@@ -849,13 +871,13 @@ double wedge_jacobian(int num_nodes, const double coordinates[][3])
       coordinates[2][2] - coordinates[5][2]);
 
     current_jacobian = vec2 % (vec1 * vec3);
-    min_jacobian = std::min(current_jacobian, min_jacobian);
+    min_jacobian = fmin(current_jacobian, min_jacobian);
 
     if (min_jacobian > 0)
     {
-      return (double)std::min(min_jacobian, VERDICT_DBL_MAX);
+      return fmin(min_jacobian, VERDICT_DBL_MAX);
     }
-    return (double)std::max(min_jacobian, -VERDICT_DBL_MAX);
+    return fmax(min_jacobian, -VERDICT_DBL_MAX);
   }
 }
 
@@ -880,16 +902,16 @@ double wedge_jacobian(int num_nodes, const double coordinates[][3])
  Reference : Adapted from section 7.3
  Verdict Function : wedge_distortion
  */
-double wedge_distortion(int num_nodes, const double coordinates[][3])
+VERDICT_HOST_DEVICE double wedge_distortion(int num_nodes, const double coordinates[][3])
 {
   double jacobian = wedge_jacobian(num_nodes, coordinates);
   double master_volume = 0.433013;
   double current_volume = wedge_volume(num_nodes, coordinates);
   double distortion = VERDICT_DBL_MAX;
-  if (std::abs(current_volume) > 0.0)
+  if (fabs(current_volume) > 0.0)
     distortion = jacobian * master_volume / current_volume / 0.866025;
 
-  if (std::isnan(distortion))
+  if (isnan(distortion))
   {
     return VERDICT_DBL_MAX;
   }
@@ -917,7 +939,7 @@ double wedge_distortion(int num_nodes, const double coordinates[][3])
    Reference : Adapted from section 5.21
    Verdict Function : wedge_max_stretch
    */
-double wedge_max_stretch(int /*num_nodes*/, const double coordinates[][3])
+VERDICT_HOST_DEVICE double wedge_max_stretch(int /*num_nodes*/, const double coordinates[][3])
 {
   // This function finds the stretch of the 3 quadrilateral faces and returns the maximum value
 
@@ -981,13 +1003,13 @@ double wedge_max_stretch(int /*num_nodes*/, const double coordinates[][3])
   }
   stretch3 = quad_stretch(4, quad_face);
 
-  stretch = std::max({ stretch1, stretch2, stretch3 });
+  stretch = fmax(stretch1, fmax(stretch2, stretch3));
 
   if (stretch > 0)
   {
-    return (double)std::min(stretch, VERDICT_DBL_MAX);
+    return fmin(stretch, VERDICT_DBL_MAX);
   }
-  return (double)std::max(stretch, -VERDICT_DBL_MAX);
+  return fmax(stretch, -VERDICT_DBL_MAX);
 }
 
 /*
@@ -1007,7 +1029,7 @@ double wedge_max_stretch(int /*num_nodes*/, const double coordinates[][3])
    Reference : Adapted from section 6.14 and 7.11
    Verdict Function : wedge_scaled_jacobian
    */
-double wedge_scaled_jacobian(int /*num_nodes*/, const double coordinates[][3])
+VERDICT_HOST_DEVICE double wedge_scaled_jacobian(int /*num_nodes*/, const double coordinates[][3])
 {
   double min_jacobian = 0, current_jacobian = 0, lengths = 42;
   VerdictVector vec1, vec2, vec3;
@@ -1022,7 +1044,7 @@ double wedge_scaled_jacobian(int /*num_nodes*/, const double coordinates[][3])
   vec3.set(coordinates[2][0] - coordinates[0][0], coordinates[2][1] - coordinates[0][1],
     coordinates[2][2] - coordinates[0][2]);
 
-  lengths = std::sqrt(vec1.length_squared() * vec2.length_squared() * vec3.length_squared());
+  lengths = sqrt(vec1.length_squared() * vec2.length_squared() * vec3.length_squared());
 
   current_jacobian = (vec2 % (vec1 * vec3));
   min_jacobian = current_jacobian / lengths;
@@ -1037,10 +1059,10 @@ double wedge_scaled_jacobian(int /*num_nodes*/, const double coordinates[][3])
   vec3.set(coordinates[0][0] - coordinates[1][0], coordinates[0][1] - coordinates[1][1],
     coordinates[0][2] - coordinates[1][2]);
 
-  lengths = std::sqrt(vec1.length_squared() * vec2.length_squared() * vec3.length_squared());
+  lengths = sqrt(vec1.length_squared() * vec2.length_squared() * vec3.length_squared());
 
   current_jacobian = vec2 % (vec1 * vec3);
-  min_jacobian = std::min(current_jacobian / lengths, min_jacobian);
+  min_jacobian = fmin(current_jacobian / lengths, min_jacobian);
 
   // node 2
   vec1.set(coordinates[0][0] - coordinates[2][0], coordinates[0][1] - coordinates[2][1],
@@ -1052,10 +1074,10 @@ double wedge_scaled_jacobian(int /*num_nodes*/, const double coordinates[][3])
   vec3.set(coordinates[1][0] - coordinates[2][0], coordinates[1][1] - coordinates[2][1],
     coordinates[1][2] - coordinates[2][2]);
 
-  lengths = std::sqrt(vec1.length_squared() * vec2.length_squared() * vec3.length_squared());
+  lengths = sqrt(vec1.length_squared() * vec2.length_squared() * vec3.length_squared());
 
   current_jacobian = vec2 % (vec1 * vec3);
-  min_jacobian = std::min(current_jacobian / lengths, min_jacobian);
+  min_jacobian = fmin(current_jacobian / lengths, min_jacobian);
 
   // node 3
   vec1.set(coordinates[0][0] - coordinates[3][0], coordinates[0][1] - coordinates[3][1],
@@ -1067,10 +1089,10 @@ double wedge_scaled_jacobian(int /*num_nodes*/, const double coordinates[][3])
   vec3.set(coordinates[5][0] - coordinates[3][0], coordinates[5][1] - coordinates[3][1],
     coordinates[5][2] - coordinates[3][2]);
 
-  lengths = std::sqrt(vec1.length_squared() * vec2.length_squared() * vec3.length_squared());
+  lengths = sqrt(vec1.length_squared() * vec2.length_squared() * vec3.length_squared());
 
   current_jacobian = vec2 % (vec1 * vec3);
-  min_jacobian = std::min(current_jacobian / lengths, min_jacobian);
+  min_jacobian = fmin(current_jacobian / lengths, min_jacobian);
 
   // node 4
   vec1.set(coordinates[1][0] - coordinates[4][0], coordinates[1][1] - coordinates[4][1],
@@ -1082,10 +1104,10 @@ double wedge_scaled_jacobian(int /*num_nodes*/, const double coordinates[][3])
   vec3.set(coordinates[3][0] - coordinates[4][0], coordinates[3][1] - coordinates[4][1],
     coordinates[3][2] - coordinates[4][2]);
 
-  lengths = std::sqrt(vec1.length_squared() * vec2.length_squared() * vec3.length_squared());
+  lengths = sqrt(vec1.length_squared() * vec2.length_squared() * vec3.length_squared());
 
   current_jacobian = vec2 % (vec1 * vec3);
-  min_jacobian = std::min(current_jacobian / lengths, min_jacobian);
+  min_jacobian = fmin(current_jacobian / lengths, min_jacobian);
 
   // node 5
   vec1.set(coordinates[3][0] - coordinates[5][0], coordinates[3][1] - coordinates[5][1],
@@ -1097,18 +1119,18 @@ double wedge_scaled_jacobian(int /*num_nodes*/, const double coordinates[][3])
   vec3.set(coordinates[2][0] - coordinates[5][0], coordinates[2][1] - coordinates[5][1],
     coordinates[2][2] - coordinates[5][2]);
 
-  lengths = std::sqrt(vec1.length_squared() * vec2.length_squared() * vec3.length_squared());
+  lengths = sqrt(vec1.length_squared() * vec2.length_squared() * vec3.length_squared());
 
   current_jacobian = vec2 % (vec1 * vec3);
-  min_jacobian = std::min(current_jacobian / lengths, min_jacobian);
+  min_jacobian = fmin(current_jacobian / lengths, min_jacobian);
 
-  min_jacobian *= 2 / std::sqrt(3.0);
+  min_jacobian *= 2 / sqrt(3.0);
 
   if (min_jacobian > 0)
   {
-    return (double)std::min(min_jacobian, VERDICT_DBL_MAX);
+    return fmin(min_jacobian, VERDICT_DBL_MAX);
   }
-  return (double)std::max(min_jacobian, -VERDICT_DBL_MAX);
+  return fmax(min_jacobian, -VERDICT_DBL_MAX);
 }
 
 /*
@@ -1126,7 +1148,7 @@ double wedge_scaled_jacobian(int /*num_nodes*/, const double coordinates[][3])
    Reference : Adapted from section 7.12
    Verdict Function : wedge_shape
    */
-double wedge_shape(int /*num_nodes*/, const double coordinates[][3])
+VERDICT_HOST_DEVICE double wedge_shape(int /*num_nodes*/, const double coordinates[][3])
 {
   double current_jacobian = 0, current_shape, norm_jacobi = 0;
   double min_shape = 1.0;
@@ -1145,10 +1167,10 @@ double wedge_shape(int /*num_nodes*/, const double coordinates[][3])
   current_jacobian = vec2 % (vec1 * vec3);
   if (current_jacobian > VERDICT_DBL_MIN)
   {
-    norm_jacobi = current_jacobian * 2.0 / std::sqrt(3.0);
-    current_shape = 3 * std::pow(norm_jacobi, two_thirds) /
+    norm_jacobi = current_jacobian * 2.0 / sqrt(3.0);
+    current_shape = 3 * pow(norm_jacobi, two_thirds) /
       (vec1.length_squared() + vec2.length_squared() + vec3.length_squared());
-    min_shape = std::min(current_shape, min_shape);
+    min_shape = fmin(current_shape, min_shape);
   }
   else
   {
@@ -1168,10 +1190,10 @@ double wedge_shape(int /*num_nodes*/, const double coordinates[][3])
   current_jacobian = vec2 % (vec1 * vec3);
   if (current_jacobian > VERDICT_DBL_MIN)
   {
-    norm_jacobi = current_jacobian * 2.0 / std::sqrt(3.0);
-    current_shape = 3 * std::pow(norm_jacobi, two_thirds) /
+    norm_jacobi = current_jacobian * 2.0 / sqrt(3.0);
+    current_shape = 3 * pow(norm_jacobi, two_thirds) /
       (vec1.length_squared() + vec2.length_squared() + vec3.length_squared());
-    min_shape = std::min(current_shape, min_shape);
+    min_shape = fmin(current_shape, min_shape);
   }
   else
   {
@@ -1191,10 +1213,10 @@ double wedge_shape(int /*num_nodes*/, const double coordinates[][3])
   current_jacobian = vec2 % (vec1 * vec3);
   if (current_jacobian > VERDICT_DBL_MIN)
   {
-    norm_jacobi = current_jacobian * 2.0 / std::sqrt(3.0);
-    current_shape = 3 * std::pow(norm_jacobi, two_thirds) /
+    norm_jacobi = current_jacobian * 2.0 / sqrt(3.0);
+    current_shape = 3 * pow(norm_jacobi, two_thirds) /
       (vec1.length_squared() + vec2.length_squared() + vec3.length_squared());
-    min_shape = std::min(current_shape, min_shape);
+    min_shape = fmin(current_shape, min_shape);
   }
   else
   {
@@ -1214,10 +1236,10 @@ double wedge_shape(int /*num_nodes*/, const double coordinates[][3])
   current_jacobian = vec2 % (vec1 * vec3);
   if (current_jacobian > VERDICT_DBL_MIN)
   {
-    norm_jacobi = current_jacobian * 2.0 / std::sqrt(3.0);
-    current_shape = 3 * std::pow(norm_jacobi, two_thirds) /
+    norm_jacobi = current_jacobian * 2.0 / sqrt(3.0);
+    current_shape = 3 * pow(norm_jacobi, two_thirds) /
       (vec1.length_squared() + vec2.length_squared() + vec3.length_squared());
-    min_shape = std::min(current_shape, min_shape);
+    min_shape = fmin(current_shape, min_shape);
   }
   else
   {
@@ -1237,10 +1259,10 @@ double wedge_shape(int /*num_nodes*/, const double coordinates[][3])
   current_jacobian = vec2 % (vec1 * vec3);
   if (current_jacobian > VERDICT_DBL_MIN)
   {
-    norm_jacobi = current_jacobian * 2.0 / std::sqrt(3.0);
-    current_shape = 3 * std::pow(norm_jacobi, two_thirds) /
+    norm_jacobi = current_jacobian * 2.0 / sqrt(3.0);
+    current_shape = 3 * pow(norm_jacobi, two_thirds) /
       (vec1.length_squared() + vec2.length_squared() + vec3.length_squared());
-    min_shape = std::min(current_shape, min_shape);
+    min_shape = fmin(current_shape, min_shape);
   }
   else
   {
@@ -1260,10 +1282,10 @@ double wedge_shape(int /*num_nodes*/, const double coordinates[][3])
   current_jacobian = vec2 % (vec1 * vec3);
   if (current_jacobian > VERDICT_DBL_MIN)
   {
-    norm_jacobi = current_jacobian * 2.0 / std::sqrt(3.0);
-    current_shape = 3 * std::pow(norm_jacobi, two_thirds) /
+    norm_jacobi = current_jacobian * 2.0 / sqrt(3.0);
+    current_shape = 3 * pow(norm_jacobi, two_thirds) /
       (vec1.length_squared() + vec2.length_squared() + vec3.length_squared());
-    min_shape = std::min(current_shape, min_shape);
+    min_shape = fmin(current_shape, min_shape);
   }
   else
   {
@@ -1294,12 +1316,12 @@ double wedge_shape(int /*num_nodes*/, const double coordinates[][3])
  Reference : Adapted from section 7.7
  Verdict Function : wedge_max_aspect_frobenius or wedge_condition
  */
-double wedge_condition(int /*num_nodes*/, const double coordinates[][3])
+VERDICT_HOST_DEVICE double wedge_condition(int /*num_nodes*/, const double coordinates[][3])
 {
   return wedge_max_aspect_frobenius(6, coordinates);
 }
 
-void make_wedge_faces(const double coordinates[][3], double tri1[][3], double tri2[][3],
+VERDICT_HOST_DEVICE void make_wedge_faces(const double coordinates[][3], double tri1[][3], double tri2[][3],
   double quad1[][3], double quad2[][3], double quad3[][3])
 {
   // tri1

--- a/VerdictVector.cpp
+++ b/VerdictVector.cpp
@@ -46,8 +46,10 @@ VERDICT_HOST_DEVICE double VerdictVector::interior_angle(const VerdictVector& ot
   }
   else
   {
+#if !defined(__HIP_DEVICE_COMPILE__)
     assert(len1 > 0);
     assert(len2 > 0);
+#endif
   }
 
   if ((cosAngle > 1.0) && (cosAngle < 1.0001))
@@ -66,7 +68,9 @@ VERDICT_HOST_DEVICE double VerdictVector::interior_angle(const VerdictVector& ot
   }
   else
   {
+#if !defined(__HIP_DEVICE_COMPILE__)
     assert(cosAngle < 1.0001 && cosAngle > -1.0001);
+#endif
   }
 
   return ((angleRad * 180.) / VERDICT_PI);

--- a/VerdictVector.cpp
+++ b/VerdictVector.cpp
@@ -21,13 +21,13 @@
 #include "VerdictVector.hpp"
 #include "verdict.h"
 
-#include <cmath>
+#include <math.h>
 
 namespace VERDICT_NAMESPACE
 {
 
 // scale the length of the vector to be the new_length
-VerdictVector& VerdictVector::length(const double new_length)
+VERDICT_HOST_DEVICE VerdictVector& VerdictVector::length(const double new_length)
 {
   double len = this->length();
   xVal *= new_length / len;
@@ -36,7 +36,7 @@ VerdictVector& VerdictVector::length(const double new_length)
   return *this;
 }
 
-double VerdictVector::interior_angle(const VerdictVector& otherVector)
+VERDICT_HOST_DEVICE double VerdictVector::interior_angle(const VerdictVector& otherVector)
 {
   double cosAngle = 0., angleRad = 0., len1, len2 = 0.;
 
@@ -53,16 +53,16 @@ double VerdictVector::interior_angle(const VerdictVector& otherVector)
   if ((cosAngle > 1.0) && (cosAngle < 1.0001))
   {
     cosAngle = 1.0;
-    angleRad = std::acos(cosAngle);
+    angleRad = acos(cosAngle);
   }
   else if (cosAngle < -1.0 && cosAngle > -1.0001)
   {
     cosAngle = -1.0;
-    angleRad = std::acos(cosAngle);
+    angleRad = acos(cosAngle);
   }
   else if (cosAngle >= -1.0 && cosAngle <= 1.0)
   {
-    angleRad = std::acos(cosAngle);
+    angleRad = acos(cosAngle);
   }
   else
   {
@@ -72,7 +72,7 @@ double VerdictVector::interior_angle(const VerdictVector& otherVector)
   return ((angleRad * 180.) / VERDICT_PI);
 }
 
-VerdictVector::VerdictVector(const double xyz[3])
+VERDICT_HOST_DEVICE VerdictVector::VerdictVector(const double xyz[3])
   : xVal(xyz[0])
   , yVal(xyz[1])
   , zVal(xyz[2])

--- a/VerdictVector.hpp
+++ b/VerdictVector.hpp
@@ -356,7 +356,9 @@ VERDICT_HOST_DEVICE inline VerdictVector& VerdictVector::operator*=(const double
 // Scales all values by 1/scalar
 VERDICT_HOST_DEVICE inline VerdictVector& VerdictVector::operator/=(const double scalar)
 {
+#if !defined(__HIP_DEVICE_COMPILE__)
   assert(scalar != 0);
+#endif
   xVal /= scalar;
   yVal /= scalar;
   zVal /= scalar;

--- a/VerdictVector.hpp
+++ b/VerdictVector.hpp
@@ -28,7 +28,7 @@
 #include "verdict.h"
 
 #include <cassert>
-#include <cmath>
+#include <math.h>
 
 namespace VERDICT_NAMESPACE
 {
@@ -36,141 +36,141 @@ class VerdictVector
 {
 public:
   //- Heading: Constructors and Destructor
-  VerdictVector(); //- Default constructor.
+  VERDICT_HOST_DEVICE VerdictVector(); //- Default constructor.
 
-  VerdictVector(const double x, const double y, const double z);
+  VERDICT_HOST_DEVICE VerdictVector(const double x, const double y, const double z);
   //- Constructor: create vector from three components
 
-  VerdictVector(const double xyz[3]);
+  VERDICT_HOST_DEVICE VerdictVector(const double xyz[3]);
   //- Constructor: create vector from tuple
 
-  VerdictVector(const VerdictVector& tail, const VerdictVector& head);
-  VerdictVector(const double *tail, const double *head, int dimension);
-  VerdictVector(const double *tail, const double *head);
+  VERDICT_HOST_DEVICE VerdictVector(const VerdictVector& tail, const VerdictVector& head);
+  VERDICT_HOST_DEVICE VerdictVector(const double *tail, const double *head, int dimension);
+  VERDICT_HOST_DEVICE VerdictVector(const double *tail, const double *head);
   //- Constructor for a VerdictVector starting at tail and pointing
   //- to head.
 
-  template <typename ARG1, typename ARG2, typename ARG3> VerdictVector(ARG1, ARG2, ARG3) = delete;
+  template <typename ARG1, typename ARG2, typename ARG3> VERDICT_HOST_DEVICE VerdictVector(ARG1, ARG2, ARG3) = delete;
   //- define this template to avoid ambiguity between the (double, double, double) and (double *, double *, int) constructors
 
-  VerdictVector(const VerdictVector& copy_from); //- Copy Constructor
+  VERDICT_HOST_DEVICE VerdictVector(const VerdictVector& copy_from); //- Copy Constructor
 
   //- Heading: Set and Inquire Functions
-  void set(const double xv, const double yv, const double zv);
+  VERDICT_HOST_DEVICE void set(const double xv, const double yv, const double zv);
   //- Change vector components to {x}, {y}, and {z}
 
-  void set(const double xyz[3]);
+  VERDICT_HOST_DEVICE void set(const double xyz[3]);
   //- Change vector components to xyz[0], xyz[1], xyz[2]
 
-  void set(const VerdictVector& tail, const VerdictVector& head);
+  VERDICT_HOST_DEVICE void set(const VerdictVector& tail, const VerdictVector& head);
   //- Change vector to go from tail to head.
 
-  void set(const VerdictVector& to_copy);
+  VERDICT_HOST_DEVICE void set(const VerdictVector& to_copy);
   //- Same as operator=(const VerdictVector&)
 
-  double x() const; //- Return x component of vector
+  VERDICT_HOST_DEVICE double x() const; //- Return x component of vector
 
-  double y() const; //- Return y component of vector
+  VERDICT_HOST_DEVICE double y() const; //- Return y component of vector
 
-  double z() const; //- Return z component of vector
+  VERDICT_HOST_DEVICE double z() const; //- Return z component of vector
 
-  void get_xyz(double& x, double& y, double& z); //- Get x, y, z components
-  void get_xyz(double xyz[3]);                   //- Get xyz tuple
+  VERDICT_HOST_DEVICE void get_xyz(double& x, double& y, double& z); //- Get x, y, z components
+  VERDICT_HOST_DEVICE void get_xyz(double xyz[3]);                   //- Get xyz tuple
 
-  double& r(); //- Return r component of vector, if (r,theta) format
+  VERDICT_HOST_DEVICE double& r(); //- Return r component of vector, if (r,theta) format
 
-  double& theta(); //- Return theta component of vector, if (r,theta) format
+  VERDICT_HOST_DEVICE double& theta(); //- Return theta component of vector, if (r,theta) format
 
-  void x(const double xv); //- Set x component of vector
+  VERDICT_HOST_DEVICE void x(const double xv); //- Set x component of vector
 
-  void y(const double yv); //- Set y component of vector
+  VERDICT_HOST_DEVICE void y(const double yv); //- Set y component of vector
 
-  void z(const double zv); //- Set z component of vector
+  VERDICT_HOST_DEVICE void z(const double zv); //- Set z component of vector
 
-  void r(const double xv); //- Set r component of vector, if (r,theta) format
+  VERDICT_HOST_DEVICE void r(const double xv); //- Set r component of vector, if (r,theta) format
 
-  void theta(const double yv); //- Set theta component of vector, if (r,theta) format
+  VERDICT_HOST_DEVICE void theta(const double yv); //- Set theta component of vector, if (r,theta) format
 
-  double normalize();
+  VERDICT_HOST_DEVICE double normalize();
   //- Normalize (set magnitude equal to 1) vector - return the magnitude
 
-  VerdictVector& length(const double new_length);
+  VERDICT_HOST_DEVICE VerdictVector& length(const double new_length);
   //- Change length of vector to {new_length}. Can be used to move a
   //- location a specified distance from the origin in the current
   //- orientation.
 
-  double length() const;
+  VERDICT_HOST_DEVICE double length() const;
   //- Calculate the length of the vector.
   //- Use {length_squared()} if only comparing lengths, not adding.
 
-  double length_squared() const;
+  VERDICT_HOST_DEVICE double length_squared() const;
   //- Calculate the squared length of the vector.
   //- Faster than {length()} since it eliminates the square root if
   //- only comparing other lengths.
 
-  double interior_angle(const VerdictVector& otherVector);
+  VERDICT_HOST_DEVICE double interior_angle(const VerdictVector& otherVector);
   //- Calculate the interior angle: acos((a%b)/(|a||b|))
   //- Returns angle in degrees.
 
-  void perpendicular_z();
+  VERDICT_HOST_DEVICE void perpendicular_z();
   //- Transform this vector to a perpendicular one, leaving
   //- z-component alone. Rotates clockwise about the z-axis by pi/2.
 
   //- Heading: Operator Overloads  *****************************
-  VerdictVector& operator+=(const VerdictVector& vec);
+  VERDICT_HOST_DEVICE VerdictVector& operator+=(const VerdictVector& vec);
   //- Compound Assignment: addition: {this = this + vec}
 
-  VerdictVector& operator-=(const VerdictVector& vec);
+  VERDICT_HOST_DEVICE VerdictVector& operator-=(const VerdictVector& vec);
   //- Compound Assignment: subtraction: {this = this - vec}
 
-  VerdictVector& operator*=(const VerdictVector& vec);
+  VERDICT_HOST_DEVICE VerdictVector& operator*=(const VerdictVector& vec);
   //- Compound Assignment: cross product: {this = this * vec},
   //- non-commutative
 
-  VerdictVector& operator*=(const double scalar);
+  VERDICT_HOST_DEVICE VerdictVector& operator*=(const double scalar);
   //- Compound Assignment: multiplication: {this = this * scalar}
 
-  VerdictVector& operator/=(const double scalar);
+  VERDICT_HOST_DEVICE VerdictVector& operator/=(const double scalar);
   //- Compound Assignment: division: {this = this / scalar}
 
-  VerdictVector operator-() const;
+  VERDICT_HOST_DEVICE VerdictVector operator-() const;
   //- unary negation.
 
-  friend VerdictVector operator~(const VerdictVector& vec);
+  VERDICT_HOST_DEVICE friend VerdictVector operator~(const VerdictVector& vec);
   //- normalize. Returns a new vector which is a copy of {vec},
   //- scaled such that {|vec|=1}. Uses overloaded bitwise NOT operator.
 
-  friend VerdictVector operator+(const VerdictVector& v1, const VerdictVector& v2);
+  VERDICT_HOST_DEVICE friend VerdictVector operator+(const VerdictVector& v1, const VerdictVector& v2);
   //- vector addition
 
-  friend VerdictVector operator-(const VerdictVector& v1, const VerdictVector& v2);
+  VERDICT_HOST_DEVICE friend VerdictVector operator-(const VerdictVector& v1, const VerdictVector& v2);
   //- vector subtraction
 
-  friend VerdictVector operator*(const VerdictVector& v1, const VerdictVector& v2);
+  VERDICT_HOST_DEVICE friend VerdictVector operator*(const VerdictVector& v1, const VerdictVector& v2);
   //- vector cross product, non-commutative
 
-  friend VerdictVector operator*(const VerdictVector& v1, const double sclr);
+  VERDICT_HOST_DEVICE friend VerdictVector operator*(const VerdictVector& v1, const double sclr);
   //- vector * scalar
 
-  friend VerdictVector operator*(const double sclr, const VerdictVector& v1);
+  VERDICT_HOST_DEVICE friend VerdictVector operator*(const double sclr, const VerdictVector& v1);
   //- scalar * vector
 
-  friend double operator%(const VerdictVector& v1, const VerdictVector& v2);
+  VERDICT_HOST_DEVICE friend double operator%(const VerdictVector& v1, const VerdictVector& v2);
   //- dot product
 
-  static double Dot(const VerdictVector& v1, const VerdictVector& v2);
+  static VERDICT_HOST_DEVICE double Dot(const VerdictVector& v1, const VerdictVector& v2);
   //- dot product
 
-  friend VerdictVector operator/(const VerdictVector& v1, const double sclr);
+  VERDICT_HOST_DEVICE friend VerdictVector operator/(const VerdictVector& v1, const double sclr);
   //- vector / scalar
 
-  friend int operator==(const VerdictVector& v1, const VerdictVector& v2);
+  VERDICT_HOST_DEVICE friend int operator==(const VerdictVector& v1, const VerdictVector& v2);
   //- Equality operator
 
-  friend int operator!=(const VerdictVector& v1, const VerdictVector& v2);
+  VERDICT_HOST_DEVICE friend int operator!=(const VerdictVector& v1, const VerdictVector& v2);
   //- Inequality operator
 
-  VerdictVector& operator=(const VerdictVector& from);
+  VERDICT_HOST_DEVICE VerdictVector& operator=(const VerdictVector& from);
 
 private:
   double xVal; //- x component of vector.
@@ -178,59 +178,59 @@ private:
   double zVal; //- z component of vector.
 };
 
-inline double VerdictVector::x() const
+VERDICT_HOST_DEVICE inline double VerdictVector::x() const
 {
   return xVal;
 }
-inline double VerdictVector::y() const
+VERDICT_HOST_DEVICE inline double VerdictVector::y() const
 {
   return yVal;
 }
-inline double VerdictVector::z() const
+VERDICT_HOST_DEVICE inline double VerdictVector::z() const
 {
   return zVal;
 }
-inline void VerdictVector::get_xyz(double xyz[3])
+VERDICT_HOST_DEVICE inline void VerdictVector::get_xyz(double xyz[3])
 {
   xyz[0] = xVal;
   xyz[1] = yVal;
   xyz[2] = zVal;
 }
-inline void VerdictVector::get_xyz(double& xv, double& yv, double& zv)
+VERDICT_HOST_DEVICE inline void VerdictVector::get_xyz(double& xv, double& yv, double& zv)
 {
   xv = xVal;
   yv = yVal;
   zv = zVal;
 }
-inline double& VerdictVector::r()
+VERDICT_HOST_DEVICE inline double& VerdictVector::r()
 {
   return xVal;
 }
-inline double& VerdictVector::theta()
+VERDICT_HOST_DEVICE inline double& VerdictVector::theta()
 {
   return yVal;
 }
-inline void VerdictVector::x(const double xv)
+VERDICT_HOST_DEVICE inline void VerdictVector::x(const double xv)
 {
   xVal = xv;
 }
-inline void VerdictVector::y(const double yv)
+VERDICT_HOST_DEVICE inline void VerdictVector::y(const double yv)
 {
   yVal = yv;
 }
-inline void VerdictVector::z(const double zv)
+VERDICT_HOST_DEVICE inline void VerdictVector::z(const double zv)
 {
   zVal = zv;
 }
-inline void VerdictVector::r(const double xv)
+VERDICT_HOST_DEVICE inline void VerdictVector::r(const double xv)
 {
   xVal = xv;
 }
-inline void VerdictVector::theta(const double yv)
+VERDICT_HOST_DEVICE inline void VerdictVector::theta(const double yv)
 {
   yVal = yv;
 }
-inline VerdictVector& VerdictVector::operator+=(const VerdictVector& vector)
+VERDICT_HOST_DEVICE inline VerdictVector& VerdictVector::operator+=(const VerdictVector& vector)
 {
   xVal += vector.x();
   yVal += vector.y();
@@ -238,7 +238,7 @@ inline VerdictVector& VerdictVector::operator+=(const VerdictVector& vector)
   return *this;
 }
 
-inline VerdictVector& VerdictVector::operator-=(const VerdictVector& vector)
+VERDICT_HOST_DEVICE inline VerdictVector& VerdictVector::operator-=(const VerdictVector& vector)
 {
   xVal -= vector.x();
   yVal -= vector.y();
@@ -246,7 +246,7 @@ inline VerdictVector& VerdictVector::operator-=(const VerdictVector& vector)
   return *this;
 }
 
-inline VerdictVector& VerdictVector::operator*=(const VerdictVector& vector)
+VERDICT_HOST_DEVICE inline VerdictVector& VerdictVector::operator*=(const VerdictVector& vector)
 {
   double xcross, ycross, zcross;
   xcross = yVal * vector.z() - zVal * vector.y();
@@ -258,42 +258,42 @@ inline VerdictVector& VerdictVector::operator*=(const VerdictVector& vector)
   return *this;
 }
 
-inline VerdictVector::VerdictVector(const VerdictVector& copy_from)
+VERDICT_HOST_DEVICE inline VerdictVector::VerdictVector(const VerdictVector& copy_from)
   : xVal(copy_from.xVal)
   , yVal(copy_from.yVal)
   , zVal(copy_from.zVal)
 {
 }
 
-inline VerdictVector::VerdictVector()
+VERDICT_HOST_DEVICE inline VerdictVector::VerdictVector()
   : xVal(0)
   , yVal(0)
   , zVal(0)
 {
 }
 
-inline VerdictVector::VerdictVector(const double *tail, const double *head, int dimension)
+VERDICT_HOST_DEVICE inline VerdictVector::VerdictVector(const double *tail, const double *head, int dimension)
   : xVal{head[0] - tail[0]}
   , yVal{head[1] - tail[1]}
   , zVal{dimension == 2 ? 0.0 : head[2] - tail[2]}
 {
 }
 
-inline VerdictVector::VerdictVector(const double *tail, const double *head)
+VERDICT_HOST_DEVICE inline VerdictVector::VerdictVector(const double *tail, const double *head)
   : xVal{head[0] - tail[0]}
   , yVal{head[1] - tail[1]}
   , zVal{head[2] - tail[2]}
 {
 }
 
-inline VerdictVector::VerdictVector(const VerdictVector& tail, const VerdictVector& head)
+VERDICT_HOST_DEVICE inline VerdictVector::VerdictVector(const VerdictVector& tail, const VerdictVector& head)
   : xVal(head.xVal - tail.xVal)
   , yVal(head.yVal - tail.yVal)
   , zVal(head.zVal - tail.zVal)
 {
 }
 
-inline VerdictVector::VerdictVector(const double xIn, const double yIn, const double zIn)
+VERDICT_HOST_DEVICE inline VerdictVector::VerdictVector(const double xIn, const double yIn, const double zIn)
   : xVal(xIn)
   , yVal(yIn)
   , zVal(zIn)
@@ -303,35 +303,35 @@ inline VerdictVector::VerdictVector(const double xIn, const double yIn, const do
 // This sets the vector to be perpendicular to it's current direction.
 // NOTE:
 //      This is a 2D function.  It only works in the XY Plane.
-inline void VerdictVector::perpendicular_z()
+VERDICT_HOST_DEVICE inline void VerdictVector::perpendicular_z()
 {
   double temp = x();
   x(y());
   y(-temp);
 }
 
-inline void VerdictVector::set(const double xv, const double yv, const double zv)
+VERDICT_HOST_DEVICE inline void VerdictVector::set(const double xv, const double yv, const double zv)
 {
   xVal = xv;
   yVal = yv;
   zVal = zv;
 }
 
-inline void VerdictVector::set(const double xyz[3])
+VERDICT_HOST_DEVICE inline void VerdictVector::set(const double xyz[3])
 {
   xVal = xyz[0];
   yVal = xyz[1];
   zVal = xyz[2];
 }
 
-inline void VerdictVector::set(const VerdictVector& tail, const VerdictVector& head)
+VERDICT_HOST_DEVICE inline void VerdictVector::set(const VerdictVector& tail, const VerdictVector& head)
 {
   xVal = head.xVal - tail.xVal;
   yVal = head.yVal - tail.yVal;
   zVal = head.zVal - tail.zVal;
 }
 
-inline VerdictVector& VerdictVector::operator=(const VerdictVector& from)
+VERDICT_HOST_DEVICE inline VerdictVector& VerdictVector::operator=(const VerdictVector& from)
 {
   xVal = from.xVal;
   yVal = from.yVal;
@@ -339,13 +339,13 @@ inline VerdictVector& VerdictVector::operator=(const VerdictVector& from)
   return *this;
 }
 
-inline void VerdictVector::set(const VerdictVector& to_copy)
+VERDICT_HOST_DEVICE inline void VerdictVector::set(const VerdictVector& to_copy)
 {
   *this = to_copy;
 }
 
 // Scale all values by scalar.
-inline VerdictVector& VerdictVector::operator*=(const double scalar)
+VERDICT_HOST_DEVICE inline VerdictVector& VerdictVector::operator*=(const double scalar)
 {
   xVal *= scalar;
   yVal *= scalar;
@@ -354,7 +354,7 @@ inline VerdictVector& VerdictVector::operator*=(const double scalar)
 }
 
 // Scales all values by 1/scalar
-inline VerdictVector& VerdictVector::operator/=(const double scalar)
+VERDICT_HOST_DEVICE inline VerdictVector& VerdictVector::operator/=(const double scalar)
 {
   assert(scalar != 0);
   xVal /= scalar;
@@ -364,9 +364,9 @@ inline VerdictVector& VerdictVector::operator/=(const double scalar)
 }
 
 // Returns the normalized 'this'.
-inline VerdictVector operator~(const VerdictVector& vec)
+VERDICT_HOST_DEVICE inline VerdictVector operator~(const VerdictVector& vec)
 {
-  double mag = std::sqrt(vec.xVal * vec.xVal + vec.yVal * vec.yVal + vec.zVal * vec.zVal);
+  double mag = sqrt(vec.xVal * vec.xVal + vec.yVal * vec.yVal + vec.zVal * vec.zVal);
 
   VerdictVector temp = vec;
   if (mag != 0.0)
@@ -377,12 +377,12 @@ inline VerdictVector operator~(const VerdictVector& vec)
 }
 
 // Unary minus.  Negates all values in vector.
-inline VerdictVector VerdictVector::operator-() const
+VERDICT_HOST_DEVICE inline VerdictVector VerdictVector::operator-() const
 {
   return VerdictVector(-xVal, -yVal, -zVal);
 }
 
-inline VerdictVector operator+(const VerdictVector& vector1, const VerdictVector& vector2)
+VERDICT_HOST_DEVICE inline VerdictVector operator+(const VerdictVector& vector1, const VerdictVector& vector2)
 {
   double xv = vector1.x() + vector2.x();
   double yv = vector1.y() + vector2.y();
@@ -391,7 +391,7 @@ inline VerdictVector operator+(const VerdictVector& vector1, const VerdictVector
   //  return VerdictVector(vector1) += vector2;
 }
 
-inline VerdictVector operator-(const VerdictVector& vector1, const VerdictVector& vector2)
+VERDICT_HOST_DEVICE inline VerdictVector operator-(const VerdictVector& vector1, const VerdictVector& vector2)
 {
   double xv = vector1.x() - vector2.x();
   double yv = vector1.y() - vector2.y();
@@ -402,50 +402,50 @@ inline VerdictVector operator-(const VerdictVector& vector1, const VerdictVector
 
 // Cross products.
 // vector1 cross vector2
-inline VerdictVector operator*(const VerdictVector& vector1, const VerdictVector& vector2)
+VERDICT_HOST_DEVICE inline VerdictVector operator*(const VerdictVector& vector1, const VerdictVector& vector2)
 {
   return VerdictVector(vector1) *= vector2;
 }
 
 // Returns a scaled vector.
-inline VerdictVector operator*(const VerdictVector& vector1, const double scalar)
+VERDICT_HOST_DEVICE inline VerdictVector operator*(const VerdictVector& vector1, const double scalar)
 {
   return VerdictVector(vector1) *= scalar;
 }
 
 // Returns a scaled vector
-inline VerdictVector operator*(const double scalar, const VerdictVector& vector1)
+VERDICT_HOST_DEVICE inline VerdictVector operator*(const double scalar, const VerdictVector& vector1)
 {
   return VerdictVector(vector1) *= scalar;
 }
 
 // Returns a vector scaled by 1/scalar
-inline VerdictVector operator/(const VerdictVector& vector1, const double scalar)
+VERDICT_HOST_DEVICE inline VerdictVector operator/(const VerdictVector& vector1, const double scalar)
 {
   return VerdictVector(vector1) /= scalar;
 }
 
-inline int operator==(const VerdictVector& v1, const VerdictVector& v2)
+VERDICT_HOST_DEVICE inline int operator==(const VerdictVector& v1, const VerdictVector& v2)
 {
   return (v1.xVal == v2.xVal && v1.yVal == v2.yVal && v1.zVal == v2.zVal);
 }
 
-inline int operator!=(const VerdictVector& v1, const VerdictVector& v2)
+VERDICT_HOST_DEVICE inline int operator!=(const VerdictVector& v1, const VerdictVector& v2)
 {
   return (v1.xVal != v2.xVal || v1.yVal != v2.yVal || v1.zVal != v2.zVal);
 }
 
-inline double VerdictVector::length_squared() const
+VERDICT_HOST_DEVICE inline double VerdictVector::length_squared() const
 {
   return (xVal * xVal + yVal * yVal + zVal * zVal);
 }
 
-inline double VerdictVector::length() const
+VERDICT_HOST_DEVICE inline double VerdictVector::length() const
 {
-  return (std::sqrt(xVal * xVal + yVal * yVal + zVal * zVal));
+  return sqrt(length_squared())
 }
 
-inline double VerdictVector::normalize()
+VERDICT_HOST_DEVICE inline double VerdictVector::normalize()
 {
   double mag = length();
   if (mag != 0)
@@ -458,11 +458,11 @@ inline double VerdictVector::normalize()
 }
 
 // Dot Product.
-inline double operator%(const VerdictVector& vector1, const VerdictVector& vector2)
+VERDICT_HOST_DEVICE inline double operator%(const VerdictVector& vector1, const VerdictVector& vector2)
 {
   return VerdictVector::Dot(vector1, vector2);
 }
-inline double VerdictVector::Dot(const VerdictVector& vector1, const VerdictVector& vector2)
+VERDICT_HOST_DEVICE inline double VerdictVector::Dot(const VerdictVector& vector1, const VerdictVector& vector2)
 {
   return (vector1.xVal * vector2.xVal + vector1.yVal * vector2.yVal + vector1.zVal * vector2.zVal);
 }

--- a/VerdictVector.hpp
+++ b/VerdictVector.hpp
@@ -442,7 +442,7 @@ VERDICT_HOST_DEVICE inline double VerdictVector::length_squared() const
 
 VERDICT_HOST_DEVICE inline double VerdictVector::length() const
 {
-  return sqrt(length_squared())
+  return sqrt(length_squared());
 }
 
 VERDICT_HOST_DEVICE inline double VerdictVector::normalize()

--- a/unittests/verdict.test.cpp
+++ b/unittests/verdict.test.cpp
@@ -22,7 +22,7 @@
 
 #include "gtest/gtest.h"
 
-#include <cmath>
+#include <math.h>
 #include <functional>
 #include <iostream>
 #include <vector>
@@ -68,7 +68,7 @@ void runtest(test_case& this_testcase)
               << std::endl;
 
     EXPECT_NEAR(calculated_answer, expected_answer,
-      std::abs(expected_answer) * VERDICT_RELATIVE_TOL + VERDICT_ABSOLUTE_TOL);
+      fabs(expected_answer) * VERDICT_RELATIVE_TOL + VERDICT_ABSOLUTE_TOL);
 
     // old test using strings
     /*
@@ -85,7 +85,7 @@ void runtest(test_case& this_testcase)
     // for expected values of zero, we only care about absolute tolerance, not relative tolerance,
     std::string expected_v_str = expected.str();
     std::string answer_v_str = answer.str();
-    if ( std::abs(answer_from_lib) < VERDICT_ABSOLUTE_TOL )
+    if ( fabs(answer_from_lib) < VERDICT_ABSOLUTE_TOL )
     {
       std::stringstream expected_abs;
       expected_abs.setf(std::ios::scientific, std::ios::floatfield);
@@ -126,7 +126,7 @@ void runtest(test_case& this_testcase)
 TEST(verdict, tet_incircle_right)
 {
   test_case testcase = { "tet_incircle_right",
-    { { verdict::tet_inradius, 0.5 - 1. / std::sqrt(12) } }, 4,
+    { { verdict::tet_inradius, 0.5 - 1. / sqrt(12) } }, 4,
     { { 0, 0, 0 }, { 1, 0, 0 }, { 0, 1, 0 }, { 0, 0, 1 } } };
 
   runtest(testcase);
@@ -135,7 +135,7 @@ TEST(verdict, tet_incircle_right)
 TEST(verdict, tet_incircle_right2)
 {
   test_case testcase = { "tet_incircle_right2",
-    { { verdict::tet_inradius, 2.0 * (0.5 - 1. / std::sqrt(12)) } }, 4,
+    { { verdict::tet_inradius, 2.0 * (0.5 - 1. / sqrt(12)) } }, 4,
     { { 0, 0, 0 }, { 2, 0, 0 }, { 0, 2, 0 }, { 0, 0, 2 } } };
 
   runtest(testcase);
@@ -146,29 +146,29 @@ TEST(verdict, tet_incircle_equilateral)
   const double pi = verdict::VERDICT_PI;
 
   // equilateral tet, with side length 1
-  double l2 = std::sin(30 * pi / 180) / std::sin(120 * pi / 180);
-  double h = std::sqrt(1 - l2 * l2);
+  double l2 = sin(30 * pi / 180) / sin(120 * pi / 180);
+  double h = sqrt(1 - l2 * l2);
 
   test_case testcase = { "tet_incircle_equilateral",
-    { { verdict::tet_inradius, std::sqrt(6.) / 12. } }, 4,
-    { { 0, 0, 0 }, { 1, 0, 0 }, { std::cos(60 * pi / 180), std::sin(60 * pi / 180), 0 },
-      { l2 * std::cos(30 * pi / 180), l2 * std::sin(30 * pi / 180), h } } };
+    { { verdict::tet_inradius, sqrt(6.) / 12. } }, 4,
+    { { 0, 0, 0 }, { 1, 0, 0 }, { cos(60 * pi / 180), sin(60 * pi / 180), 0 },
+      { l2 * cos(30 * pi / 180), l2 * sin(30 * pi / 180), h } } };
 
   runtest(testcase);
 }
 
 TEST(verdict, tet_incircle_equilateral2)
 {
-  const double pi = 2. * std::asin(1.);
+  const double pi = 2. * asin(1.);
 
   // equilateral tet, with side length 2
-  double l2 = 2. * std::sin(30 * pi / 180) / std::sin(120 * pi / 180);
-  double h = std::sqrt(4. - l2 * l2);
+  double l2 = 2. * sin(30 * pi / 180) / sin(120 * pi / 180);
+  double h = sqrt(4. - l2 * l2);
 
   test_case testcase = { "tet_incircle_equilateral2",
-    { { verdict::tet_inradius, 2 * std::sqrt(6.) / 12. } }, 4,
-    { { 0, 0, 0 }, { 2, 0, 0 }, { 2 * std::cos(60 * pi / 180), 2 * std::sin(60 * pi / 180), 0 },
-      { l2 * std::cos(30 * pi / 180), l2 * std::sin(30 * pi / 180), h } } };
+    { { verdict::tet_inradius, 2 * sqrt(6.) / 12. } }, 4,
+    { { 0, 0, 0 }, { 2, 0, 0 }, { 2 * cos(60 * pi / 180), 2 * sin(60 * pi / 180), 0 },
+      { l2 * cos(30 * pi / 180), l2 * sin(30 * pi / 180), h } } };
 
   runtest(testcase);
 }
@@ -184,7 +184,7 @@ TEST(verdict, tet_incircle_flat)
 TEST(verdict, tet_incircle_inverted)
 {
   test_case testcase = { "tet_incircle_inverted",
-    { { verdict::tet_inradius, -0.5 + 1. / std::sqrt(12) } }, 4,
+    { { verdict::tet_inradius, -0.5 + 1. / sqrt(12) } }, 4,
     { { 0, 0, 0 }, { 1, 0, 0 }, { 0, 1, 0 }, { 0, 0, -1 } } };
 
   runtest(testcase);
@@ -286,7 +286,7 @@ TEST(verdict, wedge_simple)
 {
   test_case testcase = { "wedge_simple",
     { { verdict::wedge_volume, 0.5 }, { verdict::wedge_equiangle_skew, 0.25 },
-      { verdict::wedge_edge_ratio, std::sqrt(2.) },
+      { verdict::wedge_edge_ratio, sqrt(2.) },
       { verdict::wedge_max_aspect_frobenius, 1.1357042248 },
       { verdict::wedge_mean_aspect_frobenius, 1.0978474174 }, { verdict::wedge_distortion, 1 },
       { verdict::wedge_max_stretch, 1 } },
@@ -692,7 +692,7 @@ TEST(verdict, tet_test1)
     { { verdict::tet_volume, 166.66666667 }, { verdict::tet_condition, 1.2247448714 },
       { verdict::tet_jacobian, 1000 }, { verdict::tet_shape, 0.83994736660 },
       { verdict::tet_distortion, 1 },
-      /*  6 */ { verdict::tet_edge_ratio, std::sqrt(2.) },
+      /*  6 */ { verdict::tet_edge_ratio, sqrt(2.) },
       /*  7 */ { verdict::tet_radius_ratio, 1.3660254038 },
       /*  8 */ { verdict::tet_aspect_ratio, 1.3660254038 },
       /*  9 */ { verdict::tet_aspect_frobenius, 1.1905507890 },
@@ -811,7 +811,7 @@ TEST(verdict, hex_test2_perfect_cube)
   test_case testcase = { "hex_test2_perfect_cube",
     { { verdict::hex_skew, 0. }, { verdict::hex_taper, 0. }, { verdict::hex_volume, 1.0 },
       { verdict::hex_stretch, 1.0 }, { verdict::hex_diagonal, 1.0 },
-      { verdict::hex_dimension, 1. / std::sqrt(3.) }, { verdict::hex_condition, 1.0 },
+      { verdict::hex_dimension, 1. / sqrt(3.) }, { verdict::hex_condition, 1.0 },
       { verdict::hex_med_aspect_frobenius, 1 }, { verdict::hex_jacobian, 1.0 },
       { verdict::hex_shear, 1.0 }, { verdict::hex_shape, 1.0 }, { verdict::hex_distortion, 1.0 },
       { verdict::hex_nodal_jacobian_ratio, 1.0 }, { verdict::hex_oddy, 0. },
@@ -836,7 +836,7 @@ TEST(verdict, hex_test3_flat)
       { verdict::hex_distortion, verdict::VERDICT_DBL_MAX },
       { verdict::hex_nodal_jacobian_ratio, -verdict::VERDICT_DBL_MAX },
       { verdict::hex_oddy, verdict::VERDICT_DBL_MAX },
-      { verdict::hex_edge_ratio, 1.0 / std::sqrt(0.02) }, { verdict::hex_equiangle_skew, 0.5 } },
+      { verdict::hex_edge_ratio, 1.0 / sqrt(0.02) }, { verdict::hex_equiangle_skew, 0.5 } },
     8,
     { // squashed flat
       { 0, 0, 0 }, { 1, 0, 0 }, { 1, 1, 0 }, { 0, 1, 0 }, { 0.1, 0.1, 0 }, { 0.9, 0.1, 0 },
@@ -854,7 +854,7 @@ TEST(verdict, hex_test4_inside_out)
       /*  3 */ { verdict::hex_volume, -1. }, // !=
       /*  4 */ { verdict::hex_stretch, 1 },
       /*  5 */ { verdict::hex_diagonal, 1.0 },
-      /*  6 */ { verdict::hex_dimension, 1. / std::sqrt(3.) },
+      /*  6 */ { verdict::hex_dimension, 1. / sqrt(3.) },
       /*  7 */ { verdict::hex_condition, verdict::VERDICT_DBL_MAX },            // !=
       /*  8 */ { verdict::hex_med_aspect_frobenius, verdict::VERDICT_DBL_MAX }, // !=
       /*  9 */ { verdict::hex_jacobian, -1. },                                  // !=

--- a/verdict.h
+++ b/verdict.h
@@ -59,6 +59,12 @@ using namespace VERDICT_NAMESPACE;
 }
 #endif
 
+#if defined(__CUDACC__) || defined(__HIPCC__)
+#define VERDICT_HOST_DEVICE __host__ __device__
+#else
+#define VERDICT_HOST_DEVICE
+#endif
+
 /*! \mainpage
   Verdict is a library used to calculate metrics on the following type of elements:
 
@@ -116,147 +122,147 @@ using namespace VERDICT_NAMESPACE;
 
 namespace VERDICT_NAMESPACE
 {
-const double VERDICT_DBL_MIN = 1.0E-30;
-const double VERDICT_DBL_MAX = 1.0E+30;
-const double VERDICT_PI = 3.1415926535897932384626;
+static constexpr double VERDICT_DBL_MIN = 1.0E-30;
+static constexpr double VERDICT_DBL_MAX = 1.0E+30;
+static constexpr double VERDICT_PI = 3.1415926535897932384626;
 
 /* quality functions for hex elements */
 
 //! Calculates hex edge ratio metric.
 /**  Hmax / Hmin where Hmax and Hmin are respectively the maximum and the
      minimum edge lengths */
-VERDICT_EXPORT double hex_edge_ratio(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double hex_edge_ratio(int num_nodes, const double coordinates[][3]);
 
 //! Calculates hex maximum of edge ratio
 /**Maximum edge length ratio at hex center.
   Reference --- L.M. Taylor, and D.P. Flanagan, Pronto3D - A Three Dimensional Transient
      Solid Dynamics Program, SAND87-1912, Sandia National Laboratories, 1989. */
-VERDICT_EXPORT double hex_max_edge_ratio(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double hex_max_edge_ratio(int num_nodes, const double coordinates[][3]);
 
 //! Calculates hex skew metric.
 /** Maximum |cos A| where A is the angle between edges at hex center.
   Reference --- L.M. Taylor, and D.P. Flanagan, Pronto3D - A Three Dimensional Transient
      Solid Dynamics Program, SAND87-1912, Sandia National Laboratories, 1989. */
-VERDICT_EXPORT double hex_skew(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double hex_skew(int num_nodes, const double coordinates[][3]);
 
 //! Calculates hex taper metric
 /**  Maximum ratio of lengths derived from opposite edges.
   Reference --- L.M. Taylor, and D.P. Flanagan, Pronto3D - A Three Dimensional Transient
      Solid Dynamics Program, SAND87-1912, Sandia National Laboratories, 1989. */
-VERDICT_EXPORT double hex_taper(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double hex_taper(int num_nodes, const double coordinates[][3]);
 
 //! Calculates hex volume
 /**  Jacobian at hex center.
   Reference --- L.M. Taylor, and D.P. Flanagan, Pronto3D - A Three Dimensional Transient
      Solid Dynamics Program, SAND87-1912, Sandia National Laboratories, 1989. */
-VERDICT_EXPORT double hex_volume(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double hex_volume(int num_nodes, const double coordinates[][3]);
 
 //! Calculates hex stretch metric
 /**  Sqrt(3) * minimum edge length / maximum diagonal length.
   Reference --- FIMESH code */
-VERDICT_EXPORT double hex_stretch(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double hex_stretch(int num_nodes, const double coordinates[][3]);
 
 //! Calculates hex diagonal metric
 /** Minimum diagonal length / maximum diagonal length.
   Reference --- Unknown */
-VERDICT_EXPORT double hex_diagonal(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double hex_diagonal(int num_nodes, const double coordinates[][3]);
 
 //! Calculates hex dimension metric
 /** Pronto-specific characteristic length for stable time step calculation.
     Char_length = Volume / 2 grad Volume.
   Reference --- L.M. Taylor, and D.P. Flanagan, Pronto3D - A Three Dimensional Transient
      Solid Dynamics Program, SAND87-1912, Sandia National Laboratories, 1989. */
-VERDICT_EXPORT double hex_dimension(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double hex_dimension(int num_nodes, const double coordinates[][3]);
 
 //! Calculates hex timestep metric
 /**  timestep = char_length / (M/density),
   where M = youngs_modulus*(1 - poissons_ratio) / ((1 - 2 * poissons_ratio)*(1 + poissons_ratio));
 */
-VERDICT_EXPORT double hex_timestep(int num_nodes, const double coordinates[][3], double density,
+VERDICT_EXPORT VERDICT_HOST_DEVICE double hex_timestep(int num_nodes, const double coordinates[][3], double density,
   double poissons_ratio, double youngs_modulus);
 
 //! Calculates hex oddy metric
-VERDICT_EXPORT double hex_oddy(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double hex_oddy(int num_nodes, const double coordinates[][3]);
 
 //! Calculates hex condition metric
 /** Average Frobenius condition number of the Jacobian matrix at 8 corners. */
-VERDICT_EXPORT double hex_med_aspect_frobenius(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double hex_med_aspect_frobenius(int num_nodes, const double coordinates[][3]);
 
 //! Calculates hex condition metric
 /** Maximum Frobenius condition number of the Jacobian matrix at 8 corners.
    Reference --- P. Knupp, Achieving Finite Element Mesh Quality via
    Optimization of the Jacobian Matrix Norm and Associated Quantities,
    Intl. J. Numer. Meth. Engng. 2000, 48:1165-1185. */
-VERDICT_EXPORT double hex_max_aspect_frobenius(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double hex_max_aspect_frobenius(int num_nodes, const double coordinates[][3]);
 //! Calculates hex condition metric. This is a synonym for \ref hex_max_aspect_frobenius.
-VERDICT_EXPORT double hex_condition(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double hex_condition(int num_nodes, const double coordinates[][3]);
 
 //! Calculates hex jacobian metric
 /** Minimum pointwise volume of local map at 8 corners & center of hex.
    Reference --- P. Knupp, Achieving Finite Element Mesh Quality via
    Optimization of the Jacobian Matrix Norm and Associated Quantities,
    Intl. J. Numer. Meth. Engng. 2000, 48:1165-1185. */
-VERDICT_EXPORT double hex_jacobian(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double hex_jacobian(int num_nodes, const double coordinates[][3]);
 
 //! Calculates hex scaled jacobian metric
 /** Minimum Jacobian divided by the lengths of the 3 edge vectors.
    Reference --- P. Knupp, Achieving Finite Element Mesh Quality via
    Optimization of the Jacobian Matrix Norm and Associated Quantities,
    Intl. J. Numer. Meth. Engng. 2000, 48:1165-1185. */
-VERDICT_EXPORT double hex_scaled_jacobian(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double hex_scaled_jacobian(int num_nodes, const double coordinates[][3]);
 
 //! Return min(Jacobian) / max(Jacobian) over all nodes
 /** Turn the Jacobian determinates into a normalized quality ratio. Detects element skewness.
     If the maximum nodal jacobian is negative the element is fully inverted, and return a huge
     negative number, -VERDICT_DBL_MAX.
     Currently only the first 8 nodes are supported. */
-VERDICT_EXPORT double hex_nodal_jacobian_ratio2(int num_nodes, const double* coordinates);
-VERDICT_EXPORT double hex_nodal_jacobian_ratio(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double hex_nodal_jacobian_ratio2(int num_nodes, const double* coordinates);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double hex_nodal_jacobian_ratio(int num_nodes, const double coordinates[][3]);
 
 //! Calculates hex shear metric
 /** 3/Mean Ratio of Jacobian Skew matrix.
    Reference --- P. Knupp, Algebraic Mesh Quality Metrics for
    Unstructured Initial Meshes, submitted for publication.  */
-VERDICT_EXPORT double hex_shear(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double hex_shear(int num_nodes, const double coordinates[][3]);
 
 //! Calculates hex shape metric.
 /** 3/Mean Ratio of weighted Jacobian matrix.
    Reference --- P. Knupp, Algebraic Mesh Quality Metrics for
    Unstructured Initial Meshes, submitted for publication.  */
-VERDICT_EXPORT double hex_shape(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double hex_shape(int num_nodes, const double coordinates[][3]);
 
 //! Calculates hex relative size metric.
 /** 3/Mean Ratio of weighted Jacobian matrix.
    Reference --- P. Knupp, Algebraic Mesh Quality Metrics for
    Unstructured Initial Meshes, submitted for publication.  */
 
-VERDICT_EXPORT double hex_relative_size_squared(
+VERDICT_EXPORT VERDICT_HOST_DEVICE double hex_relative_size_squared(
   int num_nodes, const double coordinates[][3], double average_hex_volume);
 
 //! Calculates hex shape-size metric.
 /** Product of Shape and Relative Size.
    Reference --- P. Knupp, Algebraic Mesh Quality Metrics for
    Unstructured Initial Meshes, submitted for publication.  */
-VERDICT_EXPORT double hex_shape_and_size(
+VERDICT_EXPORT VERDICT_HOST_DEVICE double hex_shape_and_size(
   int num_nodes, const double coordinates[][3], double average_hex_volume);
 
 //! Calculates hex shear-size metric
 /** Product of Shear and Relative Size.
    Reference --- P. Knupp, Algebraic Mesh Quality Metrics for
    Unstructured Initial Meshes, submitted for publication.  */
-VERDICT_EXPORT double hex_shear_and_size(
+VERDICT_EXPORT VERDICT_HOST_DEVICE double hex_shear_and_size(
   int num_nodes, const double coordinates[][3], double average_hex_volume);
 
 //! Calculates hex distortion metric
 /** {min(|J|)/actual volume}*parent volume, parent volume = 8 for hex.
    Reference --- SDRC/IDEAS Simulation: Finite Element Modeling--User's Guide */
-VERDICT_EXPORT double hex_distortion(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double hex_distortion(int num_nodes, const double coordinates[][3]);
 
-VERDICT_EXPORT double hex_equiangle_skew(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double hex_equiangle_skew(int num_nodes, const double coordinates[][3]);
 
 /* quality functions for tet elements */
 
-VERDICT_EXPORT double tet_inradius(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tet_inradius(int num_nodes, const double coordinates[][3]);
 
 //! Calculates tet timestep metric
 /**  timestep = char_length / (M/density),
@@ -264,207 +270,207 @@ VERDICT_EXPORT double tet_inradius(int num_nodes, const double coordinates[][3])
   For a tet10, char_length = 2.3 * smallest tet_inradius or the 12 subtets
   For all other tets, char_length = tet_inradius of 4 noded tet
 */
-VERDICT_EXPORT double tet_timestep(int num_nodes, const double coordinates[][3], double density,
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tet_timestep(int num_nodes, const double coordinates[][3], double density,
   double poissons_ratio, double youngs_modulus);
 
 //! Calculates tet edge ratio metric.
 /**  Hmax / Hmin where Hmax and Hmin are respectively the maximum and the
    minimum edge lengths */
-VERDICT_EXPORT double tet_edge_ratio(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tet_edge_ratio(int num_nodes, const double coordinates[][3]);
 
 //! Calculates tet radius ratio metric.
 /** CR / (3.0 * IR)  where CR = circumsphere radius, IR = inscribed sphere radius.
     Reference ---  V. N. Parthasarathy et al, A comparison of tetrahedron
     quality measures, Finite Elem. Anal. Des., Vol 15(1993), 255-261. */
-VERDICT_EXPORT double tet_radius_ratio(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tet_radius_ratio(int num_nodes, const double coordinates[][3]);
 
 //! Calculates tet aspect ratio metric.
 /**  Hmax / (2 sqrt(6) r) where Hmax and r respectively denote the greatest edge
    length and the inradius of the tetrahedron
    Reference ---  P. Frey and P.-L. George, Meshing, Hermes (2000). */
-VERDICT_EXPORT double tet_aspect_ratio(int num_nodes, const double coordinates[][3]);
-VERDICT_EXPORT double tet_aspect_ratio_from_loc_ptrs(int num_nodes, const double * const *coordinates);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tet_aspect_ratio(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tet_aspect_ratio_from_loc_ptrs(int num_nodes, const double * const *coordinates);
 
 //! Calculates tet aspect gamma metric.
 /**  Srms**3 / (8.479670*V) where Srms = sqrt(Sum(Si**2)/6), Si = edge length.
    Reference ---  V. N. Parthasarathy et al, A comparison of tetrahedron
    quality measures, Finite Elem. Anal. Des., Vol 15(1993), 255-261. */
-VERDICT_EXPORT double tet_aspect_gamma(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tet_aspect_gamma(int num_nodes, const double coordinates[][3]);
 
 //! Calculates tet aspect frobenius metric.
 /** Frobenius condition number when the reference element is regular
    Reference --- P. Knupp, Achieving Finite Element Mesh Quality via
    Optimization of the Jacobian Matrix Norm and Associated Quantities,
    Intl. J. Numer. Meth. Engng. 2000, 48:1165-1185. */
-VERDICT_EXPORT double tet_aspect_frobenius(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tet_aspect_frobenius(int num_nodes, const double coordinates[][3]);
 
 //! Calculates tet minimum dihedral angle.
 /** Minimum (nonoriented) dihedral angle of a tetrahedron, expressed in degrees. */
-VERDICT_EXPORT double tet_minimum_angle(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tet_minimum_angle(int num_nodes, const double coordinates[][3]);
 
 //! Calculates tet collapse ratio metric.
 /**  Collapse ratio */
-VERDICT_EXPORT double tet_collapse_ratio(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tet_collapse_ratio(int num_nodes, const double coordinates[][3]);
 
 //! Calculates tet volume.
 /** (1/6) * Jacobian at corner node.
    Reference ---  V. N. Parthasarathy et al, A comparison of tetrahedron
    quality measures, Finite Elem. Anal. Des., Vol 15(1993), 255-261. */
-VERDICT_EXPORT double tet_volume(int num_nodes, const double coordinates[][3]);
-VERDICT_EXPORT double tet_volume_from_loc_ptrs(int num_nodes, const double * const *coordinates);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tet_volume(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tet_volume_from_loc_ptrs(int num_nodes, const double * const *coordinates);
 
 //! Calculates tet condition metric.
 /** Condition number of the Jacobian matrix at any corner.
    Reference --- P. Knupp, Achieving Finite Element Mesh Quality via
    Optimization of the Jacobian Matrix Norm and Associated Quantities,
    Intl. J. Numer. Meth. Engng. 2000, 48:1165-1185. */
-VERDICT_EXPORT double tet_condition(int num_nodes, const double coordinates[][3]);
-VERDICT_EXPORT double tet_condition_from_loc_ptrs(int num_nodes, const double * const *coordinates);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tet_condition(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tet_condition_from_loc_ptrs(int num_nodes, const double * const *coordinates);
 
 //! Calculates tet jacobian.
 /** Minimum pointwise volume at any corner.
    Reference --- P. Knupp, Achieving Finite Element Mesh Quality via
    Optimization of the Jacobian Matrix Norm and Associated Quantities,
    Intl. J. Numer. Meth. Engng. 2000, 48:1165-1185. */
-VERDICT_EXPORT double tet_jacobian(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tet_jacobian(int num_nodes, const double coordinates[][3]);
 
 //! Calculates tet scaled jacobian.
 /** Minimum Jacobian divided by the lengths of 3 edge vectors
    Reference --- P. Knupp, Achieving Finite Element Mesh Quality via
    Optimization of the Jacobian Matrix Norm and Associated Quantities,
    Intl. J. Numer. Meth. Engng. 2000, 48:1165-1185. */
-VERDICT_EXPORT double tet_scaled_jacobian(int num_nodes, const double coordinates[][3]);
-VERDICT_EXPORT double tet_scaled_jacobian_from_loc_ptrs(int num_nodes, const double * const * coordinates);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tet_scaled_jacobian(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tet_scaled_jacobian_from_loc_ptrs(int num_nodes, const double * const * coordinates);
 
 //! Calculates tet mean ratio.
 /** Ratio of tet volume to volume of an equilateral tet with the same RMS edge length
    Reference 1 --- Compere & Remacle A mesh adaptation framework for dealing with large deforming
    meshes, IJNME 2010 82:843-867 Reference 2 --- Danial Ibanez - PhD Thesis, Conformal Mesh
    Adaptation on Heterogeneous Supercomputers */
-VERDICT_EXPORT double tet_mean_ratio(int num_nodes, const double coordinates[][3]);
-VERDICT_EXPORT double tet_mean_ratio_from_loc_ptrs(int num_nodes, const double * const *coordinates);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tet_mean_ratio(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tet_mean_ratio_from_loc_ptrs(int num_nodes, const double * const *coordinates);
 
 //! Calculates the minimum normalized inner radius of a tet
 /** Ratio of the minimum subtet inner radius to tet outer radius*/
 /* Currently supports tetra 10 and 4.*/
-VERDICT_EXPORT double tet_normalized_inradius(int num_nodes, const double coordinates[][3]);
-VERDICT_EXPORT double tet_normalized_inradius_from_loc_ptrs(int num_nodes, const double * const *coordinates);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tet_normalized_inradius(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tet_normalized_inradius_from_loc_ptrs(int num_nodes, const double * const *coordinates);
 
 //! Calculates tet shape metric.
 /** 3/Mean Ratio of weighted Jacobian matrix.
    Reference --- P. Knupp, Algebraic Mesh Quality Metrics for
    Unstructured Initial Meshes, submitted for publication. */
-VERDICT_EXPORT double tet_shape(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tet_shape(int num_nodes, const double coordinates[][3]);
 
 //! Calculates tet relative size metric.
 /** Min( J, 1/J ), where J is determinant of weighted Jacobian matrix.
    Reference --- P. Knupp, Algebraic Mesh Quality Metrics for
    Unstructured Initial Meshes, submitted for publication. */
-VERDICT_EXPORT double tet_relative_size_squared(
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tet_relative_size_squared(
   int num_nodes, const double coordinates[][3], double average_tet_size);
 
 //! Calculates tet shape-size metric.
 /** Product of Shape and Relative Size.
    Reference --- P. Knupp, Algebraic Mesh Quality Metrics for
    Unstructured Initial Meshes, submitted for publication. */
-VERDICT_EXPORT double tet_shape_and_size(
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tet_shape_and_size(
   int num_nodes, const double coordinates[][3], double average_tet_size);
 
 //! Calculates tet distortion metric.
 /** {min(|J|)/actual volume}*parent volume, parent volume = 1/6 for tet.
    Reference --- SDRC/IDEAS Simulation: Finite Element Modeling--User's Guide */
-VERDICT_EXPORT double tet_distortion(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tet_distortion(int num_nodes, const double coordinates[][3]);
 
 //! Calculates tet equivolume skew metric.
-VERDICT_EXPORT double tet_equivolume_skew(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tet_equivolume_skew(int num_nodes, const double coordinates[][3]);
 
 //! Calculates tet squish index metric.
-VERDICT_EXPORT double tet_squish_index(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tet_squish_index(int num_nodes, const double coordinates[][3]);
 
 //! Calculates tet equiangle skew metric.
-VERDICT_EXPORT double tet_equiangle_skew(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tet_equiangle_skew(int num_nodes, const double coordinates[][3]);
 
 /* quality functions for pyramid elements */
 
 //! Calculates pyramid volume.
-VERDICT_EXPORT double pyramid_volume(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double pyramid_volume(int num_nodes, const double coordinates[][3]);
 //! Caluculates pyramid jacaboian based on bisecting into two tets
-VERDICT_EXPORT double pyramid_jacobian(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double pyramid_jacobian(int num_nodes, const double coordinates[][3]);
 
 //! Calculates pyramid scaled jacaboian based on bisecting into two tets
-VERDICT_EXPORT double pyramid_scaled_jacobian(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double pyramid_scaled_jacobian(int num_nodes, const double coordinates[][3]);
 
 //! Calculates the pyramid shape metric.
 /** 4 divided by the minimum mean ratio of the Jacobian matrix at each
     element corner.
     Reference -- Adaptation of Hex shape metric. */
-VERDICT_EXPORT double pyramid_shape(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double pyramid_shape(int num_nodes, const double coordinates[][3]);
 
 //! Calculates the pyramid equiangle skew metric.
-VERDICT_EXPORT double pyramid_equiangle_skew(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double pyramid_equiangle_skew(int num_nodes, const double coordinates[][3]);
 
 /* quality functions for wedge elements */
 
 //! Calculates wedge volume.
-VERDICT_EXPORT double wedge_volume(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double wedge_volume(int num_nodes, const double coordinates[][3]);
 
 //! Calculates wedge edge ratio metric.
 /**  Hmax / Hmin where Hmax and Hmin are respectively the maximum and the
    minimum edge lengths */
-VERDICT_EXPORT double wedge_edge_ratio(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double wedge_edge_ratio(int num_nodes, const double coordinates[][3]);
 
 //! Calculates wedge max aspect forbenius.
 /** max(F_0123, F_1204, F_2015, F_3540, F_4351, F_5432)
   Reference --- Adaptation of hex max aspect frobenius */
-VERDICT_EXPORT double wedge_max_aspect_frobenius(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double wedge_max_aspect_frobenius(int num_nodes, const double coordinates[][3]);
 
 //! Calculates wedge mean aspect forbenius.
 /** 1/6 * (F_0123 + F_1204 + F+2015 + F_3540 + F_4351 + F_5432)
   Reference --- Adaptation of hex mean aspect frobenius */
-VERDICT_EXPORT double wedge_mean_aspect_frobenius(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double wedge_mean_aspect_frobenius(int num_nodes, const double coordinates[][3]);
 
 //! Calculates wedge jacobian metric.
 /** min{((L_2 X L_0) * L_3)_k}
    Reference --- Adaptation of Tet jacobian metric. */
-VERDICT_EXPORT double wedge_jacobian(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double wedge_jacobian(int num_nodes, const double coordinates[][3]);
 
 //! Calculates wedge distortion metric.
 /** {min(|J|)/actual volume}*parent volume.
    Reference --- Adaptation of Hex distortion metric. */
-VERDICT_EXPORT double wedge_distortion(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double wedge_distortion(int num_nodes, const double coordinates[][3]);
 
 //! Calculates the wedge stretch
 /** Minimum of the stretch of each quadrilateral face.
     Reference -- See quadrilateral stretch */
-VERDICT_EXPORT double wedge_max_stretch(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double wedge_max_stretch(int num_nodes, const double coordinates[][3]);
 
 //! Calculates wedge scaled jacobian metric.
 /** Reference --- Adaptation of Hex and Tet scaled jacobian metric. */
-VERDICT_EXPORT double wedge_scaled_jacobian(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double wedge_scaled_jacobian(int num_nodes, const double coordinates[][3]);
 
 //! Calculates the wedge shape metric.
 /** 3 divided by the minimum mean ratio of the Jacobian matrix at each
     element corner.
     Reference -- Adaptaation of Hex shape metric. */
-VERDICT_EXPORT double wedge_shape(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double wedge_shape(int num_nodes, const double coordinates[][3]);
 
 //! Calculates wedge max aspect forbenius.
 /** max(F_0123, F_1204, F_2015, F_3540, F_4351, F_5432)
   Reference --- Adaptation of hex max aspect frobenius */
-VERDICT_EXPORT double wedge_condition(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double wedge_condition(int num_nodes, const double coordinates[][3]);
 
 //! Calculates wedge equiangle skew metric
-VERDICT_EXPORT double wedge_equiangle_skew(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double wedge_equiangle_skew(int num_nodes, const double coordinates[][3]);
 
 /* quality functions for knife elements */
 
 //! Calculates knife volume.
-VERDICT_EXPORT double knife_volume(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double knife_volume(int num_nodes, const double coordinates[][3]);
 
 /* quality functions for edge elements */
 
 //! Calculates edge length.
-VERDICT_EXPORT double edge_length(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double edge_length(int num_nodes, const double coordinates[][3]);
 
 /* quality functions for quad elements */
 
@@ -472,141 +478,141 @@ VERDICT_EXPORT double edge_length(int num_nodes, const double coordinates[][3]);
 /** edge ratio
     Reference --- P. P. Pebay, Planar Quadrangle Quality
     Measures, Eng. Comp., 2004, 20(2):157-173 */
-VERDICT_EXPORT double quad_edge_ratio(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double quad_edge_ratio(int num_nodes, const double coordinates[][3]);
 
 //! Calculates quad maximum of edge ratio.
 /** Maximum edge length ratio at quad center.
    Reference --- J. Robinson, CRE Method of element testing and the
    Jacobian shape parameters, Eng. Comput., Vol 4, 1987. */
-VERDICT_EXPORT double quad_max_edge_ratio(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double quad_max_edge_ratio(int num_nodes, const double coordinates[][3]);
 
 //! Calculates quad aspect ratio
 /** aspect ratio
     Reference --- P. P. Pebay, Planar Quadrangle Quality
     Measures, Eng. Comp., 2004, 20(2):157-173 */
-VERDICT_EXPORT double quad_aspect_ratio(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double quad_aspect_ratio(int num_nodes, const double coordinates[][3]);
 
 //! Calculates quad radius ratio
 /** radius ratio
     Reference --- P. P. Pebay, Planar Quadrangle Quality
     Measures, Eng. Comp., 2004, 20(2):157-173 */
-VERDICT_EXPORT double quad_radius_ratio(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double quad_radius_ratio(int num_nodes, const double coordinates[][3]);
 
 //! Calculates quad average Frobenius aspect
 /** average Frobenius aspect
     Reference --- P. P. Pebay, Planar Quadrangle Quality
     Measures, Eng. Comp., 2004, 20(2):157-173 */
-VERDICT_EXPORT double quad_med_aspect_frobenius(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double quad_med_aspect_frobenius(int num_nodes, const double coordinates[][3]);
 
 //! Calculates quad maximum Frobenius aspect
 /** average Frobenius aspect
     Reference --- P. P. Pebay, Planar Quadrangle Quality
     Measures, Eng. Comp., 2004, 20(2):157-173 */
-VERDICT_EXPORT double quad_max_aspect_frobenius(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double quad_max_aspect_frobenius(int num_nodes, const double coordinates[][3]);
 
 //! Calculates quad skew metric.
 /** Maximum |cos A| where A is the angle between edges at quad center.
    Reference --- J. Robinson, CRE Method of element testing and the
    Jacobian shape parameters, Eng. Comput., Vol 4, 1987. */
-VERDICT_EXPORT double quad_skew(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double quad_skew(int num_nodes, const double coordinates[][3]);
 
 //! Calculates quad taper metric.
 /** Maximum ratio of lengths derived from opposite edges.
    Reference --- J. Robinson, CRE Method of element testing and the
    Jacobian shape parameters, Eng. Comput., Vol 4, 1987. */
-VERDICT_EXPORT double quad_taper(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double quad_taper(int num_nodes, const double coordinates[][3]);
 
 //! Calculates quad warpage metric.
 /** Cosine of Minimum Dihedral Angle formed by Planes Intersecting in Diagonals.
    Reference --- J. Robinson, CRE Method of element testing and the
    Jacobian shape parameters, Eng. Comput., Vol 4, 1987. */
-VERDICT_EXPORT double quad_warpage(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double quad_warpage(int num_nodes, const double coordinates[][3]);
 
 //! Calculates quad area.
 /** Jacobian at quad center.
    Reference --- J. Robinson, CRE Method of element testing and the
    Jacobian shape parameters, Eng. Comput., Vol 4, 1987. */
-VERDICT_EXPORT double quad_area(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double quad_area(int num_nodes, const double coordinates[][3]);
 
 //! Calculates quad strech metric.
 /** Sqrt(2) * minimum edge length / maximum diagonal length.
    Reference --- FIMESH code. */
-VERDICT_EXPORT double quad_stretch(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double quad_stretch(int num_nodes, const double coordinates[][3]);
 
 //! Calculates quad's smallest angle.
 /** Smallest included quad angle (degrees).
    Reference --- Unknown. */
-VERDICT_EXPORT double quad_minimum_angle(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double quad_minimum_angle(int num_nodes, const double coordinates[][3]);
 
 //! Calculates quad's largest angle.
 /** Largest included quad angle (degrees).
    Reference --- Unknown. */
-VERDICT_EXPORT double quad_maximum_angle(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double quad_maximum_angle(int num_nodes, const double coordinates[][3]);
 
 //! Calculates quad oddy metric.
-VERDICT_EXPORT double quad_oddy(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double quad_oddy(int num_nodes, const double coordinates[][3]);
 
 //! Calculates quad condition number metric.
 /** Maximum condition number of the Jacobian matrix at 4 corners.
    Reference --- P. Knupp, Achieving Finite Element Mesh Quality via
    Optimization of the Jacobian Matrix Norm and Associated Quantities,
    Intl. J. Numer. Meth. Engng. 2000, 48:1165-1185. */
-VERDICT_EXPORT double quad_condition(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double quad_condition(int num_nodes, const double coordinates[][3]);
 
 //! Calculates quad jacobian.
 /** Minimum pointwise volume of local map at 4 corners & center of quad.
    Reference --- P. Knupp, Achieving Finite Element Mesh Quality via
    Optimization of the Jacobian Matrix Norm and Associated Quantities,
    Intl. J. Numer. Meth. Engng. 2000, 48:1165-1185. */
-VERDICT_EXPORT double quad_jacobian(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double quad_jacobian(int num_nodes, const double coordinates[][3]);
 
 //! Calculates quad scaled jacobian.
 /** Minimum Jacobian divided by the lengths of the 2 edge vectors.
    Reference --- P. Knupp, Achieving Finite Element Mesh Quality via
    Optimization of the Jacobian Matrix Norm and Associated Quantities,
    Intl. J. Numer. Meth. Engng. 2000, 48:1165-1185. */
-VERDICT_EXPORT double quad_scaled_jacobian(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double quad_scaled_jacobian(int num_nodes, const double coordinates[][3]);
 
 //! Calculates quad shear metric.
 /** 2/Condition number of Jacobian Skew matrix.
    Reference --- P. Knupp, Algebraic Mesh Quality Metrics for
    Unstructured Initial Meshes, submitted for publication. */
-VERDICT_EXPORT double quad_shear(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double quad_shear(int num_nodes, const double coordinates[][3]);
 
 //! Calculates quad shape metric.
 /** 2/Condition number of weighted Jacobian matrix.
    Reference --- P. Knupp, Algebraic Mesh Quality Metrics for
    Unstructured Initial Meshes, submitted for publication. */
-VERDICT_EXPORT double quad_shape(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double quad_shape(int num_nodes, const double coordinates[][3]);
 
 //! Calculates quad relative size metric.
 /** Min( J, 1/J ), where J is determinant of weighted Jacobian matrix.
    Reference --- P. Knupp, Algebraic Mesh Quality Metrics for
    Unstructured Initial Meshes, submitted for publication. */
-VERDICT_EXPORT double quad_relative_size_squared(
+VERDICT_EXPORT VERDICT_HOST_DEVICE double quad_relative_size_squared(
   int num_nodes, const double coordinates[][3], double average_quad_area);
 
 //! Calculates quad shape-size metric.
 /** Product of Shape and Relative Size.
    Reference --- P. Knupp, Algebraic Mesh Quality Metrics for
    Unstructured Initial Meshes, submitted for publication. */
-VERDICT_EXPORT double quad_shape_and_size(
+VERDICT_EXPORT VERDICT_HOST_DEVICE double quad_shape_and_size(
   int num_nodes, const double coordinates[][3], double average_quad_area);
 
 //! Calculates quad shear-size metric.
 /** Product of Shear and Relative Size.
    Reference --- P. Knupp, Algebraic Mesh Quality Metrics for
    Unstructured Initial Meshes, submitted for publication. */
-VERDICT_EXPORT double quad_shear_and_size(
+VERDICT_EXPORT VERDICT_HOST_DEVICE double quad_shear_and_size(
   int num_nodes, const double coordinates[][3], double average_quad_area);
 
 //! Calculates quad distortion metric.
 /** {min(|J|)/actual area}*parent area, parent area = 4 for quad.
    Reference --- SDRC/IDEAS Simulation: Finite Element Modeling--User's Guide */
-VERDICT_EXPORT double quad_distortion(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double quad_distortion(int num_nodes, const double coordinates[][3]);
 
 //! Calculates the quad equiangle skew
-VERDICT_EXPORT double quad_equiangle_skew(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double quad_equiangle_skew(int num_nodes, const double coordinates[][3]);
 
 /* quality functions for triangle elements */
 
@@ -614,87 +620,87 @@ VERDICT_EXPORT double quad_equiangle_skew(int num_nodes, const double coordinate
 /** edge ratio
     Reference --- P. P. Pebay & T. J. Baker, Analysis of Triangle Quality
     Measures, AMS Math. Comp., 2003, 72(244):1817-1839 */
-VERDICT_EXPORT double tri_edge_ratio(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tri_edge_ratio(int num_nodes, const double coordinates[][3]);
 
 //! Calculates triangle metric.
 /** aspect ratio
     Reference --- P. P. Pebay & T. J. Baker, Analysis of Triangle Quality
     Measures, AMS Math. Comp., 2003, 72(244):1817-1839 */
-VERDICT_EXPORT double tri_aspect_ratio(int num_nodes, const double coordinates[][3]);
-VERDICT_EXPORT double tri_aspect_ratio_from_loc_ptrs(int num_nodes, const double * const * coordinates, const int dimension = 3);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tri_aspect_ratio(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tri_aspect_ratio_from_loc_ptrs(int num_nodes, const double * const * coordinates, const int dimension = 3);
 
 //! Calculates triangle metric.
 /** radius ratio
     Reference --- P. P. Pebay & T. J. Baker, Analysis of Triangle Quality
     Measures, AMS Math. Comp., 2003, 72(244):1817-1839 */
-VERDICT_EXPORT double tri_radius_ratio(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tri_radius_ratio(int num_nodes, const double coordinates[][3]);
 
 //! Calculates triangle metric.
 /** Frobenius aspect */
-VERDICT_EXPORT double tri_aspect_frobenius(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tri_aspect_frobenius(int num_nodes, const double coordinates[][3]);
 
 //! Calculates triangle metric.
 /** Maximum included angle in triangle */
-VERDICT_EXPORT double tri_area(int num_nodes, const double coordinates[][3]);
-VERDICT_EXPORT double tri_area_from_loc_ptrs(int num_nodes, const double * const *coordinates, const int dimension = 3);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tri_area(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tri_area_from_loc_ptrs(int num_nodes, const double * const *coordinates, const int dimension = 3);
 
 //! Calculates triangle metric.
 /** Minimum included angle in triangle */
-VERDICT_EXPORT double tri_minimum_angle(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tri_minimum_angle(int num_nodes, const double coordinates[][3]);
 
 //! Calculates triangle metric.
 /** Maximum included angle in triangle */
-VERDICT_EXPORT double tri_maximum_angle(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tri_maximum_angle(int num_nodes, const double coordinates[][3]);
 
 //! Calculates triangle metric.
 /** Condition number of the Jacobian matrix.
    Reference --- P. Knupp, Achieving Finite Element Mesh Quality via
    Optimization of the Jacobian Matrix Norm and Associated Quantities,
    Intl. J. Numer. Meth. Engng. 2000, 48:1165-1185. */
-VERDICT_EXPORT double tri_condition(int num_nodes, const double coordinates[][3]);
-VERDICT_EXPORT double tri_condition_from_loc_ptrs(int num_nodes, const double * const *coordinates, const int dimension = 3);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tri_condition(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tri_condition_from_loc_ptrs(int num_nodes, const double * const *coordinates, const int dimension = 3);
 
 //! Calculates triangle metric.
 /** Minimum Jacobian divided by the lengths of 2 edge vectors.
    Reference --- P. Knupp, Achieving Finite Element Mesh Quality via
    Optimization of the Jacobian Matrix Norm and Associated Quantities,
    Intl. J. Numer. Meth. Engng. 2000, 48:1165-1185. */
-VERDICT_EXPORT double tri_scaled_jacobian(int num_nodes, const double coordinates[][3]);
-VERDICT_EXPORT double tri_scaled_jacobian_from_loc_ptrs(int num_nodes, const double * const *coordinates, const int dimension=3);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tri_scaled_jacobian(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tri_scaled_jacobian_from_loc_ptrs(int num_nodes, const double * const *coordinates, const int dimension=3);
 
 //! Calculates triangle metric.
 /** Min( J, 1/J ), where J is determinant of weighted Jacobian matrix.
    Reference ---  P. Knupp, Algebraic Mesh Quality Metrics for
    Unstructured Initial Meshes, submitted for publication. */
-VERDICT_EXPORT double tri_relative_size_squared(
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tri_relative_size_squared(
   int num_nodes, const double coordinates[][3], double average_tri_area);
 
 //! Calculates triangle metric.
 /** 2/Condition number of weighted Jacobian matrix.
    Reference ---  P. Knupp, Algebraic Mesh Quality Metrics for
    Unstructured Initial Meshes, submitted for publication. */
-VERDICT_EXPORT double tri_shape(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tri_shape(int num_nodes, const double coordinates[][3]);
 
 //! Calculates triangle metric.
 /**  Product of Shape and Relative Size.
    Reference ---  P. Knupp, Algebraic Mesh Quality Metrics for
    Unstructured Initial Meshes, submitted for publication. */
-VERDICT_EXPORT double tri_shape_and_size(
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tri_shape_and_size(
   int num_nodes, const double coordinates[][3], double average_tri_area);
 
 //! Calculates triangle metric.
 /** {min(|J|)/actual area}*parent area, parent area = 1/2 for triangular element.
    Reference --- SDRC/IDEAS Simulation: Finite Element Modeling--User's Guide */
-VERDICT_EXPORT double tri_distortion(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tri_distortion(int num_nodes, const double coordinates[][3]);
 
 //! Calculates triangle equiangle skew metric.
-VERDICT_EXPORT double tri_equiangle_skew(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tri_equiangle_skew(int num_nodes, const double coordinates[][3]);
 
 //! Calculates the minimum normalized inner radius of a high order triangle
 /** Ratio of the minimum subtet inner radius to tet outer radius*/
 /* Currently supports tri 6 and 3.*/
-VERDICT_EXPORT double tri_normalized_inradius(int num_nodes, const double coordinates[][3]);
-VERDICT_EXPORT double tri_normalized_inradius_from_loc_ptrs(int num_nodes, const double * const *coordinates, const int dimension=3);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tri_normalized_inradius(int num_nodes, const double coordinates[][3]);
+VERDICT_EXPORT VERDICT_HOST_DEVICE double tri_normalized_inradius_from_loc_ptrs(int num_nodes, const double * const *coordinates, const int dimension=3);
 } // namespace verdict
 
 #endif /* __verdict_h */

--- a/verdict_defines.hpp
+++ b/verdict_defines.hpp
@@ -22,7 +22,7 @@
 
 #include "VerdictVector.hpp"
 
-#include <cmath>
+#include <math.h>
 
 namespace VERDICT_NAMESPACE
 {
@@ -33,19 +33,17 @@ enum VerdictBoolean
   VERDICT_TRUE = 1
 };
 
-inline double determinant(double a, double b, double c, double d)
+VERDICT_HOST_DEVICE inline double determinant(double a, double b, double c, double d)
 {
   return ((a) * (d) - (b) * (c));
 }
 
-inline double determinant(VerdictVector v1, VerdictVector v2, VerdictVector v3)
+VERDICT_HOST_DEVICE inline double determinant(VerdictVector v1, VerdictVector v2, VerdictVector v3)
 {
   return VerdictVector::Dot(v1, (v2 * v3));
 }
 
-static const double sqrt_2 = std::sqrt(2.0);
-
-inline double normalize_jacobian(
+VERDICT_HOST_DEVICE inline double normalize_jacobian(
   double jacobi, VerdictVector& v1, VerdictVector& v2, VerdictVector& v3, int tet_flag = 0)
 {
   double return_value = 0.0;
@@ -60,18 +58,18 @@ inline double normalize_jacobian(
     l1 = v1.length_squared();
     l2 = v2.length_squared();
     l3 = v3.length_squared();
-    length_product = std::sqrt(l1 * l2 * l3);
+    length_product = sqrt(l1 * l2 * l3);
 
     // if some numerical scaling problem, or just plain roundoff,
     // then push back into range [-1,1].
-    if (length_product < std::abs(jacobi))
+    if (length_product < fabs(jacobi))
     {
-      length_product = std::abs(jacobi);
+      length_product = fabs(jacobi);
     }
 
     if (tet_flag == 1)
     {
-      return_value = sqrt_2 * jacobi / length_product;
+      return_value = sqrt(2.0) * jacobi / length_product;
     }
     else
     {
@@ -81,15 +79,15 @@ inline double normalize_jacobian(
   return return_value;
 }
 
-inline double norm_squared(double m11, double m21, double m12, double m22)
+VERDICT_HOST_DEVICE inline double norm_squared(double m11, double m21, double m12, double m22)
 {
   return m11 * m11 + m21 * m21 + m12 * m12 + m22 * m22;
 }
 
-inline int skew_matrix(double gm11, double gm12, double gm22, double det, double& qm11,
+VERDICT_HOST_DEVICE inline int skew_matrix(double gm11, double gm12, double gm22, double det, double& qm11,
   double& qm21, double& qm12, double& qm22)
 {
-  double tmp = std::sqrt(gm11 * gm22);
+  double tmp = sqrt(gm11 * gm22);
   if (tmp == 0)
   {
     return false;
@@ -102,7 +100,7 @@ inline int skew_matrix(double gm11, double gm12, double gm22, double det, double
   return true;
 }
 
-inline void inverse(VerdictVector x1, VerdictVector x2, VerdictVector x3, VerdictVector& u1,
+VERDICT_HOST_DEVICE inline void inverse(VerdictVector x1, VerdictVector x2, VerdictVector x3, VerdictVector& u1,
   VerdictVector& u2, VerdictVector& u3)
 {
   double detx = determinant(x1, x2, x3);
@@ -121,7 +119,7 @@ inline void inverse(VerdictVector x1, VerdictVector x2, VerdictVector x3, Verdic
   u3 /= detx;
 }
 
-inline void form_Q(const VerdictVector& v1, const VerdictVector& v2, const VerdictVector& v3,
+VERDICT_HOST_DEVICE inline void form_Q(const VerdictVector& v1, const VerdictVector& v2, const VerdictVector& v3,
   VerdictVector& q1, VerdictVector& q2, VerdictVector& q3)
 {
   double g11, g12, g13, g22, g23, g33;
@@ -133,14 +131,14 @@ inline void form_Q(const VerdictVector& v1, const VerdictVector& v2, const Verdi
   g23 = VerdictVector::Dot(v2, v3);
   g33 = VerdictVector::Dot(v3, v3);
 
-  double rtg11 = std::sqrt(g11);
-  double rtg22 = std::sqrt(g22);
-  double rtg33 = std::sqrt(g33);
+  double rtg11 = sqrt(g11);
+  double rtg22 = sqrt(g22);
+  double rtg33 = sqrt(g33);
   VerdictVector temp1;
 
   temp1 = v1 * v2;
 
-  double cross = std::sqrt(VerdictVector::Dot(temp1, temp1));
+  double cross = sqrt(VerdictVector::Dot(temp1, temp1));
 
   double q11, q21, q31;
   double q12, q22, q32;
@@ -164,7 +162,7 @@ inline void form_Q(const VerdictVector& v1, const VerdictVector& v2, const Verdi
   q3.set(q13, q23, q33);
 }
 
-inline void product(VerdictVector& a1, VerdictVector& a2, VerdictVector& a3, VerdictVector& b1,
+VERDICT_HOST_DEVICE inline void product(VerdictVector& a1, VerdictVector& a2, VerdictVector& a3, VerdictVector& b1,
   VerdictVector& b2, VerdictVector& b3, VerdictVector& c1, VerdictVector& c2, VerdictVector& c3)
 {
   VerdictVector x1, x2, x3;
@@ -178,13 +176,13 @@ inline void product(VerdictVector& a1, VerdictVector& a2, VerdictVector& a3, Ver
   c3.set(VerdictVector::Dot(x1, b3), VerdictVector::Dot(x2, b3), VerdictVector::Dot(x3, b3));
 }
 
-inline double norm_squared(VerdictVector& x1, VerdictVector& x2, VerdictVector& x3)
+VERDICT_HOST_DEVICE inline double norm_squared(VerdictVector& x1, VerdictVector& x2, VerdictVector& x3)
 
 {
   return VerdictVector::Dot(x1, x1) + VerdictVector::Dot(x2, x2) + VerdictVector::Dot(x3, x3);
 }
 
-inline double skew_x(VerdictVector& q1, VerdictVector& q2, VerdictVector& q3, VerdictVector& qw1,
+VERDICT_HOST_DEVICE inline double skew_x(VerdictVector& q1, VerdictVector& q2, VerdictVector& q3, VerdictVector& qw1,
   VerdictVector& qw2, VerdictVector& qw3)
 {
   double normsq1, normsq2, kappa;
@@ -196,7 +194,7 @@ inline double skew_x(VerdictVector& q1, VerdictVector& q2, VerdictVector& q3, Ve
   inverse(x1, x2, x3, u1, u2, u3);
   normsq1 = norm_squared(x1, x2, x3);
   normsq2 = norm_squared(u1, u2, u3);
-  kappa = std::sqrt(normsq1 * normsq2);
+  kappa = sqrt(normsq1 * normsq2);
 
   double skew = 0;
   if (kappa > VERDICT_DBL_MIN)


### PR DESCRIPTION
* Use C math functions instead of C++ ones for best compatibility with CUDA/HIP (you can use them directly in device code)
* Use constexpr for constants whenever possible so that they can be used directly in device code
* For non-constexpr constants, wrap in functions instead
* Add VERDICT_HOST_DEVICE macro to apply `__host__ __device__` specifiers to all functions